### PR TITLE
Support updated CherryPy python module

### DIFF
--- a/src/depot.py
+++ b/src/depot.py
@@ -70,27 +70,28 @@ import logging
 import os
 import os.path
 import OpenSSL.crypto as crypto
+import string
 import subprocess
 import sys
 import tempfile
 import urlparse
+import portend
 
 from imp import reload
 
 try:
         import cherrypy
         version = cherrypy.__version__.split('.')
-        if map(int, version) < [3, 1, 0]:
-                raise ImportError
-        elif map(int, version) >= [3, 3, 0]:
+        if list(map(int, version)) < [3, 1, 0]:
                 raise ImportError
 except ImportError:
-        print >> sys.stderr, """cherrypy 3.1.0 or greater (but less than """ \
-            """3.3.0) is required to use this program."""
+        print("""cherrypy 3.1.0 or greater is required to use this program.""",
+            file=sys.stderr)
         sys.exit(2)
 
 import cherrypy.process.servers
 from cherrypy.process.plugins import Daemonizer
+from cherrypy._cpdispatch import Dispatcher
 
 from pkg.misc import msg, emsg, setlocale
 from pkg.client.debugvalues import DebugValues
@@ -101,8 +102,18 @@ import pkg.config as cfg
 import pkg.portable.util as os_util
 import pkg.search_errors as search_errors
 import pkg.server.depot as ds
-import pkg.server.depotresponse as dr
 import pkg.server.repository as sr
+
+
+# Starting in CherryPy 3.2, its default dispatcher converts all punctuation to
+# underscore. Since publisher name can contain the hyphen symbol "-", in order
+# to let the dispatcher to find the correct page handler, we need to skip
+# converting the hyphen symbol.
+punc = string.punctuation.replace("-", "_")
+translate = string.maketrans(punc, "_" * len(string.punctuation))
+class Pkg5Dispatcher(Dispatcher):
+        def __init__(self, **args):
+                Dispatcher.__init__(self, translate=translate)
 
 
 class LogSink(object):
@@ -613,7 +624,7 @@ if __name__ == "__main__":
         # the program will not bind to a port.
         if not exit_ready:
                 try:
-                        cherrypy.process.servers.check_port(address, port)
+                        portend.Checker().assert_free(address, port)
                 except Exception as e:
                         emsg("pkg.depotd: unable to bind to the specified "
                             "port: {0:d}. Reason: {1}".format(port, e))
@@ -897,18 +908,15 @@ if __name__ == "__main__":
 
         # Now build our site configuration.
         conf = {
-            "/": {
-                # We have to override cherrypy's default response_class so that
-                # we have access to the write() callable to stream data
-                # directly to the client.
-                "wsgi.response_class": dr.DepotResponse,
-            },
+            "/": {},
             "/robots.txt": {
                 "tools.staticfile.on": True,
                 "tools.staticfile.filename": os.path.join(depot.web_root,
                     "robots.txt")
             },
         }
+        if list(map(int, version)) >= [3, 2, 0]:
+                conf["/"]["request.dispatch"] = Pkg5Dispatcher()
 
         proxy_base = dconf.get_property("pkg", "proxy_base")
         if proxy_base:

--- a/src/pkg/manifests/package:pkg.p5m
+++ b/src/pkg/manifests/package:pkg.p5m
@@ -256,7 +256,7 @@ file path=usr/bin/pkgsend
 file path=usr/bin/pkgsign
 file path=usr/bin/pkgsurf
 dir  path=usr/lib
-file path=usr/lib/pkg.depotd mode=0755
+file path=usr/lib/pkg.depotd mode=0755 pkg.depend.bypass-generate=.*
 dir  path=usr/share
 dir  path=usr/share/lib
 dir  path=usr/share/lib/pkg

--- a/src/tests/cli/t_pkg_depotd.py
+++ b/src/tests/cli/t_pkg_depotd.py
@@ -481,6 +481,29 @@ class TestPkgDepot(pkg5unittest.SingleDepotTestCase):
 
                 res = urllib2.urlopen(repourl)
 
+        def test_publisher_prefix(self):
+                """Test that various publisher prefixes can be understood
+                by CherryPy's dispatcher."""
+
+                if self.dc.started:
+                        self.dc.stop()
+
+                depot_url = self.dc.get_depot_url()
+                repopath = os.path.join(self.test_root, "repo")
+                self.create_repo(repopath)
+                self.dc.set_repodir(repopath)
+                pubs = ["test-hyphen", "test.dot"]
+                for p in pubs:
+                        self.pkgrepo("-s {0} add-publisher {1}".format(
+                            repopath, p))
+                self.dc.start()
+                for p in pubs:
+                        # test that the catalog file can be found
+                        url = urljoin(depot_url,
+                            "{0}/catalog/1/catalog.attrs".format(p))
+                        urlopen(url)
+                self.dc.stop()
+
 
 class TestDepotController(pkg5unittest.CliTestCase):
 

--- a/src/util/apache2/depot/depot_index.py
+++ b/src/util/apache2/depot/depot_index.py
@@ -738,6 +738,17 @@ class Pkg5Dispatch(object):
 
                 toks = path_info.lstrip("/").split("/")
                 params = request.params
+                if not params:
+                        try:
+                                # Starting in CherryPy 3.2, it seems that
+                                # query_string doesn't pass into request.params,
+                                # so try harder here.
+                                from cherrypy.lib.httputil import parse_query_string
+                                params = parse_query_string(
+                                    request.query_string)
+                                request.params.update(params)
+                        except ImportError:
+                                pass
                 file_type = toks[-1].split(".")[-1]
 
                 try:


### PR DESCRIPTION
Some of these changes are based on commits to the Oracle solaris-ips repository, although they are only up to CherryPy 5.

Tested running a package server (alongside python upgrades) and also confirmed that package signing and signature verification are working properly after these changes.

See https://github.com/omniosorg/omnios-build/pull/172