### PR TITLE
Remove message about installing system/manual

### DIFF
--- a/src/brand/pkgcreatezone
+++ b/src/brand/pkgcreatezone
@@ -50,7 +50,6 @@ m_image=$(gettext       "       Image: Preparing at %s.")
 m_incorp=$(gettext      "Sanity Check: Looking for 'entire' incorporation.")
 m_core=$(gettext	"  Installing: Packages (output follows)")
 m_smf=$(gettext		" Postinstall: Copying SMF seed repository ...")
-m_mannote=$(gettext     "        Note: Man pages can be obtained by installing pkg:/system/manual")
 
 m_usage=$(gettext "\n        install [-h]\n        install [-c certificate_file] [-k key_file] [-P publisher=uri]\n                [-e extrapkg [...]]\n        install {-a archive|-d path} {-p|-u} [-s|-v]")
 
@@ -338,8 +337,6 @@ pkglist="$pkglist $extra_packages"
 #
 LC_ALL=C $PKG install --accept --no-index --no-refresh $pkglist || \
     pkg_err_check "$f_pkg"
-
-printf "\n$m_mannote\n"
 
 printf "$m_smf"
 PROFILEDIR=etc/svc/profile


### PR DESCRIPTION
When installing an ipkg/lipkg zone, a message is displayed about installing `system/manual` in order to get man pages.

```
reaper# zoneadm -z omni install
A ZFS file system has been created for this zone.
Sanity Check: Looking for 'entire' incorporation.
       Image: Preparing at /data/zone/omni/root.
   Publisher: Using omnios (https://pkg.omniosce.org/r151022/core).
       Cache: Using /var/pkg/publisher.
  Installing: Packages (output follows)
Packages to install: 392
Mediators to change:   1
 Services to change:   5

DOWNLOAD                                PKGS         FILES    XFER (MB)   SPEED
Completed                            392/392   37151/37151  340.2/340.2    0B/s

PHASE                                          ITEMS
Installing new actions                   60246/60246
Updating package state database                 Done
Updating package cache                           0/0
Updating image state                            Done
Creating fast lookup database                   Done

        Note: Man pages can be obtained by installing pkg:/system/manual
 Postinstall: Copying SMF seed repository ... done.
        Done: Installation completed in 61.444 seconds.

  Next Steps: Boot the zone, then log into the zone console (zlogin -C)
              to complete the configuration process.
```

This package is obsolete and man pages are available in zones by default.