### PR TITLE
Use explicit imports from OpenSSL.crypto

### DIFF
--- a/src/depot-config.py
+++ b/src/depot-config.py
@@ -40,8 +40,7 @@ import warnings
 
 from mako.template import Template
 from mako.lookup import TemplateLookup
-from OpenSSL.crypto import *
-from OpenSSL.crypto import TYPE_RSA, TYPE_DSA
+from OpenSSL.crypto import TYPE_RSA, TYPE_DSA, PKey, load_privatekey, dump_privatekey, load_certificate, dump_certificate, X509, X509Extension, FILETYPE_PEM
 
 import pkg
 import pkg.client.api_errors as apx


### PR DESCRIPTION
Using `import *` from OpenSSL.crypto is no longer importing the required modules following a recent PyOpenSSL update. This is in a component of `pkg(5)` that we don't use but I'm modifying the code to use explicit imports (which is recommended by the python documentation anyway).

This brings the test results back to our baseline.