### PR TITLE
Sparse zone updates.

### DIFF
--- a/doc/sparse.md
+++ b/doc/sparse.md
@@ -1,0 +1,162 @@
+
+# Sparse branded-zone support with IPS
+
+## Introduction
+
+A sparse branded zone is a non-global zone which shares file-systems
+with the global zone and has fewer default packages and services than a
+normal `(l)ipkg` branded zone.
+
+This makes them much smaller than a normal non-global zone and faster to
+instantiate, however they can still be used as a general-purpose OS instance
+(subject to some constraints). They are also ideal for running a VM
+instance to provide further isolation and resource controls, similar to
+Joyent's KVM zones.
+
+## Shared file-systems
+
+A sparse zone mounts the following file-systems from the global zone via
+read-only loopback mounts:
+
+* /usr
+* /sbin
+* /lib<sup>[1](#nblib)</sup>
+
+<a name="nblib">1</a>: See following section regarding `/lib/svc`
+
+These are mounted using the following lines in the brand `platform.xml`:
+
+```
+        <global_mount special="/sbin" directory="/sbin" opt="ro,nodevices" type="lofs" />
+        <global_mount special="/usr" directory="/usr" opt="ro,nodevices" type="lofs" />
+        <global_mount special="/lib" directory="/lib" opt="ro,nodevices" type="lofs" />
+```
+
+### Special consideration for /lib/svc
+
+Although the `/lib` file-system is being shared with the global zone, the
+`/lib/svc` path generally contains different content in a non-global zone
+and so cannot be shared. For example some packages only deliver services to a
+particular zone type or may deliver a different version of the service.
+
+In a sparse zone, `/lib/svc` is a separate ZFS dataset mounted on top of
+the directory from the global zone. Since OmniOS ZFS does not yet support
+the `overlay` filesystem property, this mount is done directly by the brand
+control scripts in a similar way to that in which boot-environments are
+mounted, with the addition of the `-O` flag to permit overlaying.
+
+The file-system is left mounted when the zone is halted to facilitate
+patching in that state.
+
+In order to protect against problems that may result from attempting to
+patch a sparse IPS image when the `/lib/svc` file-system is not mounted,
+a new IPS image property has been added. The `key-files` property contains
+a list of files which must be present within the image for it to be considered
+complete. If the image is not complete then patching will not be permitted.
+
+During zone creation, `/lib/svc/.org.opensolaris,pkgkey` is created and
+set to be an immutable file, and the zone image `key-files` property is set to
+`lib/svc/.org.opensolaris,pkgkey`
+
+## Partial delivery of packages
+
+Since a sparse zone contains a number of read-only file-systems containing
+content from installed packages in the global-zone, installation of packages
+which deliver actions to these file-systems will fail. Even in the case
+that the new content matches what is already present at the destination
+things such as mediated symlinks cause attempted writes to the
+target file-system.
+
+The solution for sparse zones it via a new IPS image property called
+`exclude-patterns`. This is a list of python regular expressions
+anchored at the start but not the end (as is common throughout IPS).
+
+Package installation planning proceeds just as before but during the
+consolidation phase, actions that deliver to or remove from a target
+matching one of these patterns are suppressed. This suppression mechanism
+is the same one that IPS already uses to suppress null changes such as when
+a target already matches or a hardlink has been reversed.
+
+For a sparse zone, the `exclude-patterns` property is set to:
+
+```
+    [
+	'usr/',
+	'sbin/',
+	'lib/(?!svc)'
+    ]
+```
+
+With the negative look-ahead allowing `/lib/svc` whilst preventing anything
+else being delivered to the read-only `/lib`. Note the trailing slash which
+still allows for delivery of the top-level directory (and therefore the
+eventual mountpoint) itself.
+
+## Reducing the number of installed packages
+
+In order to facilitate the reduction of installed packages within a sparse
+zone, a new global image variant has been introduced. This variant is
+named `opensolaris.imagetype` and defaults to `full` for all images.
+
+Sparse zones have this variant set to `partial` and this allows for selective
+inclusion of lines from the `entire` manifest. In particular, packages from
+the `drivers/*` and `locale/*` namespaces are excluded from sparse zones.
+
+Since the only non-global zone content delivered by these files is installed
+in `/usr`, the driver man pages and locale files are still available to the
+sparse zone but the package catalogue is greatly reduced.
+
+## Reducing active services
+
+The default set of running services within a sparse zone is reduced through
+the application of a platform-specific service manifest file -
+`/etc/svc/profile/platform_sparse.xml`
+
+## Attach/Detach
+
+TBC
+
+## Clone
+
+TBC
+
+## Examples
+
+```
+root@sparse:~# pkg variant
+VARIANT                                                                VALUE
+arch                                                                   i386
+opensolaris.imagetype                                                  partial
+opensolaris.zone                                                       nonglobal
+```
+
+```
+root@sparse:~# pkg property
+PROPERTY                       VALUE
+be-policy                      default
+ca-path                        /etc/ssl/certs
+check-certificate-revocation   False
+content-update-policy          default
+dehydrated                     []
+exclude-patterns               ['usr/', 'sbin/', 'lib/(?!svc)']
+flush-content-cache-on-success True
+key-files                      ['lib/svc/.org.opensolaris,pkgkey']
+mirror-discovery               False
+preferred-authority
+publisher-search-order         ['omnios', 'extra.omnios']
+send-uuid                      True
+signature-policy               verify
+signature-required-names       []
+trust-anchor-directory         etc/ssl/pkg
+use-system-repo                False
+```
+
+```
+root@sparse:~# zfs list -o space
+NAME                            AVAIL   USED  USEDSNAP  USEDDS  USEDREFRESERV  USEDCHILD
+rpool/zone/sparse                257G  22.6M         0     23K              0      22.6M
+rpool/zone/sparse/ROOT           257G  22.6M         0     23K              0      22.6M
+rpool/zone/sparse/ROOT/zbe       257G  22.6M         0   21.2M              0      1.34M
+rpool/zone/sparse/ROOT/zbe/svc   257G  1.34M         0   1.34M              0          0
+```
+

--- a/src/brand/Makefile
+++ b/src/brand/Makefile
@@ -71,8 +71,9 @@ ROOTFILES = \
 	$(ROOTBRANDPKG)/system-unconfigure \
 	$(ROOTBRANDPKG)/uninstall \
 	$(SPARSEBRANDPKG)/config.xml \
-	$(SPARSEBRANDPKG)/pkgcreatezone \
 	$(SPARSEBRANDPKG)/platform.xml \
+	$(SPARSEBRANDPKG)/profile.xml \
+	$(SPARSEBRANDPKG)/pkgcreatezone \
 	$(SPARSEBRANDPKG)/common.ksh \
 	$(SPARSEBRANDPKG)/verifyadm \
 	$(SPARSEBRANDPKG)/prestate \

--- a/src/brand/sparse/pkgcreatezone
+++ b/src/brand/sparse/pkgcreatezone
@@ -189,11 +189,13 @@ LC_ALL=C $PKG install --accept --no-index --no-refresh $pkglist || \
     pkg_err_check "$f_pkg"
 
 printf "$m_smf"
-PROFILEDIR=etc/svc/profile
-ln -s ns_files.xml $ZONEROOT/$PROFILEDIR/name_service.xml
-ln -s generic_limited_net.xml $ZONEROOT/$PROFILEDIR/generic.xml
-ln -s inetd_generic.xml $ZONEROOT/$PROFILEDIR/inetd_services.xml
-ln -s platform_none.xml $ZONEROOT/$PROFILEDIR/platform.xml
+PROFILEDIR=$ZONEROOT/etc/svc/profile
+cp /usr/lib/brand/sparse/profile.xml $PROFILEDIR/platform_sparse.xml
+[ -f $PROFILEDIR/platform.xml ] && rm -f $PROFILEDIR/platform.xml
+ln -s ns_files.xml $PROFILEDIR/name_service.xml
+ln -s generic_limited_net.xml $PROFILEDIR/generic.xml
+ln -s inetd_generic.xml $PROFILEDIR/inetd_services.xml
+ln -s platform_sparse.xml $PROFILEDIR/platform.xml
 
 # This was formerly done in i.manifest
 repfile=$ZONEROOT/etc/svc/repository.db
@@ -207,8 +209,6 @@ printf "$m_done\n"
 sed -i -e 's%^root::%root:$5$kr1VgdIt$OUiUAyZCDogH/uaxH71rMeQxvpDEY2yX.x0ZQRnmeb9:%' $ZONEROOT/etc/shadow
 
 printf "$m_complete\n\n" ${SECONDS}
-printf "$m_postnote\n"
-printf "$m_postnote2\n"
 
 exit $ZONE_SUBPROC_OK
 

--- a/src/brand/sparse/profile.xml
+++ b/src/brand/sparse/profile.xml
@@ -1,0 +1,42 @@
+<?xml version='1.0'?>
+<!DOCTYPE service_bundle SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
+<!--
+    This file and its contents are supplied under the terms of the
+    Common Development and Distribution License ("CDDL"), version 1.0.
+    You may only use this file in accordance with the terms of version
+    1.0 of the CDDL.
+
+    A full copy of the text of the CDDL should have accompanied this
+    source. A copy of the CDDL is also available via the Internet at
+    http://www.illumos.org/license/CDDL.
+
+    Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
+
+    This file is installed as the platform-specific service profile for
+    initial smf service configuration in a sparse zone.
+-->
+<service_bundle type='profile' name='sparse'>
+  <service name='system/filesystem/autofs' version='1' type='service'>
+    <instance name='default' enabled='false'/>
+  </service>
+  <service name='network/rpc/bind' version='1' type='service'>
+    <instance name='default' enabled='false'/>
+  </service>
+  <service name='network/rpc/smserver' version='1' type='service'>
+    <instance name='default' enabled='false'/>
+  </service>
+  <service name='network/rpc/gss' version='1' type='service'>
+    <instance name='default' enabled='false'/>
+  </service>
+  <service name='network/security/ktkt_warn' version='1' type='service'>
+    <instance name='default' enabled='false'/>
+  </service>
+  <service name='network/routing-setup' version='1' type='service'>
+    <property_group name='routeadm' type='framework'>
+        <propval name='default-ipv4-routing' type='boolean' value='false' />
+        <propval name='default-ipv6-routing' type='boolean' value='false' />
+        <propval name='ipv4-routing-set' type='boolean' value='false' />
+        <propval name='ipv6-routing-set' type='boolean' value='false' />
+    </property_group>
+  </service>
+</service_bundle>

--- a/src/modules/client/image.py
+++ b/src/modules/client/image.py
@@ -574,7 +574,7 @@ in the environment or by setting simulate_cmdpath in DebugValues.""")
                             self.imgdir, self.transport,
                             self.cfg.get_policy("use-system-repo"))
 
-                for keyf in self.get_property("key-files"):
+                for keyf in self.get_property(imageconfig.KEY_FILES):
                         if not os.path.exists(self.root + os.path.sep + keyf):
                                 raise apx.ImageMissingKeyFile(keyf)
 

--- a/src/modules/client/imageconfig.py
+++ b/src/modules/client/imageconfig.py
@@ -60,6 +60,8 @@ MIRROR_DISCOVERY = "mirror-discovery"
 SEND_UUID = "send-uuid"
 USE_SYSTEM_REPO = "use-system-repo"
 CHECK_CERTIFICATE_REVOCATION = "check-certificate-revocation"
+EXCLUDE_PATTERNS = "exclude-patterns"
+KEY_FILES = "key-files"
 
 default_policies = {
     BE_POLICY: "default",
@@ -191,8 +193,8 @@ class ImageConfig(cfg.FileConfig):
                         default=default_policies[
                             CHECK_CERTIFICATE_REVOCATION]),
                     cfg.PropList("dehydrated"),
-                    cfg.PropList("exclude-patterns"),
-                    cfg.PropList("key-files")
+                    cfg.PropList(EXCLUDE_PATTERNS),
+                    cfg.PropList(KEY_FILES)
                 ]),
                 cfg.PropertySection("facet", properties=[
                     cfg.PropertyTemplate("^facet\..*", prop_type=cfg.PropBool),

--- a/src/modules/client/imageplan.py
+++ b/src/modules/client/imageplan.py
@@ -57,6 +57,7 @@ import pkg.client.pkg_solver as pkg_solver
 import pkg.client.pkgdefs as pkgdefs
 import pkg.client.pkgplan as pkgplan
 import pkg.client.plandesc as plandesc
+import pkg.client.imageconfig as imageconfig
 import pkg.digest as digest
 import pkg.fmri
 import pkg.manifest as manifest
@@ -3794,7 +3795,8 @@ class ImagePlan(object):
                 # If the image has an exclude-patterns property, build a
                 # regular expression to describe the targets that should
                 # be pruned from the plan actions.
-                ooce_exclude = self.image.get_property("exclude-patterns")
+                ooce_exclude = self.image.get_property(
+                    imageconfig.EXCLUDE_PATTERNS)
                 if len(ooce_exclude):
                         exclude_regex = "^(?:" + ("|".join(ooce_exclude)) + ")"
                         ooce_re = relib.compile(exclude_regex)

--- a/src/pkg/manifests/system:zones:brand:sparse.p5m
+++ b/src/pkg/manifests/system:zones:brand:sparse.p5m
@@ -35,6 +35,7 @@ dir  path=usr/lib/brand
 dir  path=usr/lib/brand/sparse
 file path=usr/lib/brand/sparse/config.xml mode=0644
 file path=usr/lib/brand/sparse/platform.xml mode=0644
+file path=usr/lib/brand/sparse/profile.xml mode=0644
 file path=usr/lib/brand/sparse/common.ksh mode=0755
 file path=usr/lib/brand/sparse/verifyadm mode=0755
 file path=usr/lib/brand/sparse/prestate mode=0755


### PR DESCRIPTION
Add technical overview document;
Slightly re-factor property names to use constants (as per other property usage in pkg);
Disable more services in sparse zones by default.