### PR TITLE
Remove "vm" brand

### DIFF
--- a/src/modules/client/linkedimage/zone.py
+++ b/src/modules/client/linkedimage/zone.py
@@ -488,7 +488,7 @@ def _list_zones(root, path_transform):
                 # pylint: enable=W0511
                 if z_brand not in [
                     "lipkg", "solaris", "sn1", "labeled",
-                    "sparse", "vm", "kvm", "bhyve"]:
+                    "sparse", "kvm", "bhyve"]:
                         continue
 
                 # we don't care about the global zone.


### PR DESCRIPTION
`vm` is a further cut-down version of the sparse `brand` that was experimented with early in this bloody cycle. It is now not going to be used.