### PR TITLE
Sparse zone updates, -O option.

### DIFF
--- a/src/brand/sparse/config.xml
+++ b/src/brand/sparse/config.xml
@@ -51,7 +51,7 @@
 	<attach>/usr/lib/brand/sparse/attach %z %R</attach>
 	<detach>/usr/lib/brand/sparse/detach -z %z -R %R</detach>
 	<clone>/usr/lib/brand/sparse/clone -z %z -R %R</clone>
-	<uninstall>/usr/lib/brand/ipkg/uninstall %z %R</uninstall>
+	<uninstall>/usr/lib/brand/sparse/uninstall %z %R</uninstall>
 	<prestatechange>/usr/lib/brand/sparse/prestate %z %R</prestatechange>
 	<poststatechange>/usr/lib/brand/sparse/poststate %z %R</poststatechange>
 	<query>/usr/lib/brand/shared/query %z %R</query>

--- a/src/brand/sparse/uninstall
+++ b/src/brand/sparse/uninstall
@@ -1,0 +1,198 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+#
+# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+# Use is subject to license terms.
+#
+
+#
+# get script name (bname) and path (dname)
+#
+bname=`basename $0`
+
+#
+# common shell script functions
+#
+. /usr/lib/brand/sparse/common.ksh
+. /usr/lib/brand/shared/uninstall.ksh
+
+#
+# options processing
+#
+zonename=$1
+if [ -z "$zonename" ]; then
+	printf "$f_abort\n" >&2
+	exit $ZONE_SUBPROC_FATAL
+fi
+zonepath=$2
+if [ -z "$zonepath" ]; then
+	printf "$f_abort" >&2
+	exit $ZONE_SUBPROC_FATAL
+fi
+shift 2
+
+options="FhHnv"
+options_repeat=""
+options_seen=""
+
+opt_F=""
+opt_n=""
+opt_v=""
+
+# check for bad or duplicate options
+OPTIND=1
+while getopts $options OPT ; do
+case $OPT in
+	\? ) usage_err ;; # invalid argument
+	: ) usage_err ;; # argument expected
+	* )
+		opt=`echo $OPT | sed 's/-\+//'`
+		if [ -n "$options_repeat" ]; then
+			echo $options_repeat | grep $opt >/dev/null
+			[ $? = 0 ] && break
+		fi
+		( echo $options_seen | grep $opt >/dev/null ) &&
+			usage_err
+		options_seen="${options_seen}${opt}"
+		;;
+esac
+done
+
+# check for a help request
+OPTIND=1
+while getopts :$options OPT ; do
+case $OPT in
+	h|H ) usage
+esac
+done
+
+# process options
+OPTIND=1
+while getopts :$options OPT ; do
+case $OPT in
+	F ) opt_F="-F" ;;
+	n ) opt_n="-n" ;;
+	v ) opt_v="-v" ;;
+esac
+done
+shift `expr $OPTIND - 1`
+
+[ $# -gt 0 ]  && usage_err
+
+#
+# main
+#
+zoneroot=$zonepath/root
+
+nop=""
+if [[ -n "$opt_n" ]]; then
+	nop="echo"
+	#
+	# in '-n' mode we should never return success (since we haven't
+	# actually done anything). so override ZONE_SUBPROC_OK here.
+	#
+	ZONE_SUBPROC_OK=$ZONE_SUBPROC_FATAL
+fi
+
+#
+# We want uninstall to work in the face of various problems, such as a
+# zone with no delegated root dataset or multiple active datasets, so we
+# don't use the common functions.  Instead, we do our own work here and
+# are tolerant of errors.
+#
+
+# get_current_gzbe
+CURRENT_GZBE=`/sbin/beadm list -H | /bin/nawk -F\; '{
+	# Field 3 is the BE status.  'N' is the active BE.
+	if ($3 ~ "N")
+		# Field 2 is the BE UUID
+		print $2
+	}'`
+
+if [ -z "$CURRENT_GZBE" ]; then
+	print "$f_no_gzbe"
+fi
+
+uninstall_get_zonepath_ds
+uninstall_get_zonepath_root_ds
+
+# find all the zone BEs datasets associated with this global zone BE.
+unset fs_all
+(( fs_all_c = 0 ))
+if [ -n "$CURRENT_GZBE" ]; then
+	/sbin/zfs list -H -t filesystem -o $PROP_PARENT,name \
+	    -r $ZONEPATH_RDS |
+	    while IFS="	" read uid fs; do
+
+		# only look at filesystems directly below $ZONEPATH_RDS
+		[[ "$fs" != ~()($ZONEPATH_RDS/+([^/])) ]] &&
+			continue
+
+		# match by PROP_PARENT uuid
+		[[ "$uid" != ${CURRENT_GZBE} ]] &&
+			continue
+
+		fs_all[$fs_all_c]=$fs
+		(( fs_all_c = $fs_all_c + 1 ))
+	done
+fi
+
+# If there are multiple BEs here then the overlay mounts will have clones
+# in the non-active BEs.
+# For example, if the active BE is zbe-1 then
+#     .../ROOT/zbe-1/svc is the active /lib/svc/
+# and .../ROOT/zbe/svc is a clone which will prevent its removal.
+
+# The following is not perfect but will account for the most common cases.
+# Before calling destroy_zone_datasets(), we need to promote the oldest
+# clone of the youngest snapshot for each overlay mount.
+
+# Can only do this if there is only one active top-level filesystem.
+if [ "$fs_all_c" -ne 1 ]; then
+	print "`gettext 'Error: Found $fs_all_c top-level filesystems.'`"
+	print "  ${fs_all[@]}"
+	exit $ZONE_SUBPROC_FATAL
+fi
+
+newest=
+for ov in $overlays; do
+	ds=${ov%:*}
+	fs="${fs_all[0]}/$ds"
+
+	# Find the youngest snapshot
+	youngest="`/sbin/zfs list -H -t snapshot -s creation -o name \
+	    -r "$fs" | grep "^$fs@" | tail -1`"
+
+	[ -n "$youngest" ] || continue
+
+	# Find the oldest clone of this youngest snapshot
+	clone="`/sbin/zfs list -H -t filesystem -s creation -o name,origin \
+	    -r $ZONEPATH_RDS | grep "$youngest" | head -1 | awk '{print $1}'`"
+
+	[ -z "$clone" ] && continue
+	zfs_promote "$clone"
+done
+
+destroy_zone_datasets
+
+exit $ZONE_SUBPROC_OK

--- a/src/client.py
+++ b/src/client.py
@@ -329,6 +329,7 @@ def usage(usage_error=None, cmd=None, retcode=EXIT_BADOPT, full=False,
         adv_usage["property"] = _("[-H] [propname ...]")
 
         adv_usage["set-publisher"] = _("[-Ped] [-k ssl_key] [-c ssl_cert]\n"
+            "            [-O origin_to_set|--origin_uri=origin_to_set ...]\n"
             "            [-g origin_to_add|--add-origin=origin_to_add ...]\n"
             "            [-G origin_to_remove|--remove-origin=origin_to_remove ...]\n"
             "            [-m mirror_to_add|--add-mirror=mirror_to_add ...]\n"
@@ -3766,6 +3767,7 @@ def publisher_set(op, api_inst, pargs, ssl_key, ssl_cert, origin_uri,
     set_props, add_prop_values, remove_prop_values, unset_props, repo_uri,
     proxy_uri):
         """pkg set-publisher [-Ped] [-k ssl_key] [-c ssl_cert] [--reset-uuid]
+            [-O|--origin_uri origin to set]
             [-g|--add-origin origin to add] [-G|--remove-origin origin to
             remove] [-m|--add-mirror mirror to add] [-M|--remove-mirror mirror
             to remove] [-p repo_uri] [--enable] [--disable] [--no-refresh]
@@ -3780,6 +3782,9 @@ def publisher_set(op, api_inst, pargs, ssl_key, ssl_cert, origin_uri,
             [--unset-property name of property to delete]
             [--proxy proxy to use]
             [publisher] """
+
+        if origin_uri:
+                origin_uri = misc.parse_uri(origin_uri, cwd=orig_cwd)
 
         out_json = client_api._publisher_set(op, api_inst, pargs, ssl_key,
             ssl_cert, origin_uri, reset_uuid, add_mirrors, remove_mirrors,
@@ -5255,7 +5260,7 @@ opts_mapping = {
     "approved_ca_certs":      ("", "approve-ca-cert"),
     "revoked_ca_certs":       ("", "revoke-ca-cert"),
     "unset_ca_certs":         ("", "unset-ca-cert"),
-    "origin_uri":             ("O", ""),
+    "origin_uri":             ("O", "origin-uri"),
     "reset_uuid":             ("", "reset-uuid"),
     "add_mirrors":            ("m", "add-mirror"),
     "remove_mirrors":         ("M", "remove-mirror"),

--- a/src/client.py
+++ b/src/client.py
@@ -5458,7 +5458,7 @@ def main_func():
         show_usage = False
         for opt, arg in opts:
                 if opt == "-D" or opt == "--debug":
-                        if arg in ["plan", "transport"]:
+                        if arg in ["plan", "transport", "exclude", "actions"]:
                                 key = arg
                                 value = "True"
                         else:

--- a/src/man/pkg.1
+++ b/src/man/pkg.1
@@ -235,6 +235,7 @@ pkg \- Image Packaging System retrieval client
 .LP
 .nf
 /usr/bin/pkg set-publisher [-Ped] [-c \fIssl_cert\fR] [-k \fIssl_key\fR]
+    [-O \fIorigin_to_set\fR | --origin-uri \fIorigin_to_set\fR]...
     [-g \fIorigin_to_add\fR | --add-origin \fIorigin_to_add\fR]...
     [-G \fIorigin_to_remove\fR | --remove-origin \fIorigin_to_remove\fR]...
     [-m \fImirror_to_add\fR | --add-mirror \fImirror_to_add\fR]...
@@ -2234,11 +2235,27 @@ Display only enabled publishers.
 .ne 2
 .mk
 .na
-\fB\fBpkg set-publisher\fR [-Ped] [\fB-c\fR \fIssl_cert\fR] [\fB-k\fR \fIssl_key\fR] [\fB-g\fR \fIorigin_to_add\fR | \fB--add-origin\fR \fIorigin_to_add\fR]... [\fB-G\fR \fIorigin_to_remove\fR | \fB--remove-origin\fR \fIorigin_to_remove\fR]... [\fB-m\fR \fImirror_to_add\fR | \fB--add-mirror\fR \fImirror_to_add\fR]... [\fB-M\fR \fImirror_to_remove\fR | \fB--remove-mirror\fR \fImirror_to_remove\fR]... [\fB--disable\fR] [\fB--enable\fR] [\fB--no-refresh\fR] [\fB--reset-uuid\fR] [\fB--non-sticky\fR] [\fB--sticky\fR] [\fB--search-after\fR \fIpublisher\fR] [\fB--search-before\fR \fIpublisher\fR] [\fB--search-first\fR] [\fB--approve-ca-cert\fR \fIpath_to_CA\fR] [\fB--revoke-ca-cert\fR \fIhash_of_CA_to_remove\fR] [\fB--unset-ca-cert\fR \fIhash_of_CA_to_remove\fR] [\fB--set-property\fR \fIname_of_property\fR=\fIvalue\fR] [\fB--add-property-value\fR \fIname_of_property\fR=\fIvalue_to_add\fR] [\fB--remove-property-value\fR \fIname_of_property\fR=\fIvalue_to_remove\fR] [\fB--unset-property\fR \fIname_of_property_to_delete\fR] [\fB--proxy\fR \fIproxy_to_use\fR] \fIpublisher\fR\fR
+\fB\fBpkg set-publisher\fR [-Ped] [\fB-c\fR \fIssl_cert\fR] [\fB-k\fR \fIssl_key\fR] [\fB-O\fR \fIorigin_to_set\fR | \fB--origin-uri\fR \fIorigin_to_set\fR] [\fB-g\fR \fIorigin_to_add\fR | \fB--add-origin\fR \fIorigin_to_add\fR]... [\fB-G\fR \fIorigin_to_remove\fR | \fB--remove-origin\fR \fIorigin_to_remove\fR]... [\fB-m\fR \fImirror_to_add\fR | \fB--add-mirror\fR \fImirror_to_add\fR]... [\fB-M\fR \fImirror_to_remove\fR | \fB--remove-mirror\fR \fImirror_to_remove\fR]... [\fB--disable\fR] [\fB--enable\fR] [\fB--no-refresh\fR] [\fB--reset-uuid\fR] [\fB--non-sticky\fR] [\fB--sticky\fR] [\fB--search-after\fR \fIpublisher\fR] [\fB--search-before\fR \fIpublisher\fR] [\fB--search-first\fR] [\fB--approve-ca-cert\fR \fIpath_to_CA\fR] [\fB--revoke-ca-cert\fR \fIhash_of_CA_to_remove\fR] [\fB--unset-ca-cert\fR \fIhash_of_CA_to_remove\fR] [\fB--set-property\fR \fIname_of_property\fR=\fIvalue\fR] [\fB--add-property-value\fR \fIname_of_property\fR=\fIvalue_to_add\fR] [\fB--remove-property-value\fR \fIname_of_property\fR=\fIvalue_to_remove\fR] [\fB--unset-property\fR \fIname_of_property_to_delete\fR] [\fB--proxy\fR \fIproxy_to_use\fR] \fIpublisher\fR\fR
 .ad
 .sp .6
 .RS 4n
 Update an existing publisher or add a publisher. If no options affecting search order are specified, new publishers are appended to the search order and are thus searched last.
+
+.sp
+.ne 2
+.mk
+.na
+\fB\fB-O\fR \fIorigin_to_set\fR\fR
+.ad
+.br
+.na
+\fB\fB--origin-uri\fR \fIorigin_to_set\fR\fR
+.ad
+.sp .6
+.RS 4n
+Remove all existing origins for the given publisher and set a single new one. If a client SSL key/certificate is configured and the new origin transport is https, then the SSL information will be retained in the publisher.
+.RE
+
 .sp
 .ne 2
 .mk


### PR DESCRIPTION
A couple of fixes for sparse zones so that package update actions work as expected and so they can be uninstalled when multiple BEs exist.

Also document the -O option and allow it to take a pathname (including relative) as an argument rather than insisting on a fully-qualified URI.