### PR TITLE
Replace deprecated signer method

### DIFF
--- a/src/modules/actions/signature.py
+++ b/src/modules/actions/signature.py
@@ -532,11 +532,12 @@ class SignatureAction(generic.Action):
                                     "correctly.").format(key_path))
 
                         hhash = self.__get_hash_by_name(self.hash_alg)
-                        signer = priv_key.signer(padding.PKCS1v15(), hhash())
-                        signer.update(misc.force_bytes(self.actions_to_str(acts,
-                            generic.Action.sig_version)))
-                        self.attrs["value"] = \
-                            misc.binary_to_hex(signer.finalize())
+                        self.attrs["value"] = misc.binary_to_hex(priv_key.sign(
+                                misc.force_bytes(self.actions_to_str(acts,
+                                    generic.Action.sig_version)),
+                                padding.PKCS1v15(),
+                                hhash()
+                        ))
 
         def generate_indices(self):
                 """Generates the indices needed by the search dictionary.  See


### PR DESCRIPTION
RSA.signer is deprecated as of cryptography 2.0 (we're now on 2.2)
With the latest update, the following warning is printed:

```
# ...usr/lib/python2.7/vendor-packages/pkg/actions/signature.py:535: CryptographyDeprecationWarning: signer and verifier have been deprecated. Please use sign and verify instead.
#   signer = priv_key.signer(padding.PKCS1v15(), hhash())
```

Here's the fix - tested on bloody with the pkg test suite.