### PR TITLE
Set pkg user-agent for apply-hotfix downloads

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -2206,6 +2206,8 @@ def apply_hot_fix(**args):
                         hdl.setopt(pycurl.CONNECTTIMEOUT,
                             global_settings.PKG_CLIENT_CONNECT_TIMEOUT)
                         #hdl.setopt(pycurl.VERBOSE, True)
+                        hdl.setopt(pycurl.USERAGENT,
+                            misc.user_agent_str(None, 'hotfix'))
                         if args['verbose']:
                                 hdl.setopt(pycurl.NOPROGRESS, False)
                         try:


### PR DESCRIPTION
The default user-agent is similar to `PycURL/7.43.0 libcurl/7.59.0 OpenSSL/1.0.2n zlib/1.2.11 nghttp2/1.26.0`
This change sets it the same format as any other pkg operation `pkg/1519129630 (sunos i86pc; 5.11 omnios-r151024-70c39e6e15; none; hotfix)`