### PR TITLE
Sparse brand is missing uninstall script

### DIFF
--- a/src/brand/Makefile
+++ b/src/brand/Makefile
@@ -72,17 +72,18 @@ ROOTFILES = \
 	$(ROOTBRANDPKG)/system-unconfigure \
 	$(ROOTBRANDPKG)/uninstall \
 	\
-	$(SPARSEBRANDPKG)/config.xml \
-	$(SPARSEBRANDPKG)/platform.xml \
-	$(SPARSEBRANDPKG)/profile.xml \
-	$(SPARSEBRANDPKG)/pkgcreatezone \
-	$(SPARSEBRANDPKG)/common.ksh \
-	$(SPARSEBRANDPKG)/verifyadm \
-	$(SPARSEBRANDPKG)/prestate \
-	$(SPARSEBRANDPKG)/poststate \
 	$(SPARSEBRANDPKG)/attach \
+	$(SPARSEBRANDPKG)/clone \
+	$(SPARSEBRANDPKG)/common.ksh \
+	$(SPARSEBRANDPKG)/config.xml \
 	$(SPARSEBRANDPKG)/detach \
-	$(SPARSEBRANDPKG)/clone
+	$(SPARSEBRANDPKG)/pkgcreatezone \
+	$(SPARSEBRANDPKG)/platform.xml \
+	$(SPARSEBRANDPKG)/poststate \
+	$(SPARSEBRANDPKG)/prestate \
+	$(SPARSEBRANDPKG)/profile.xml \
+	$(SPARSEBRANDPKG)/uninstall \
+	$(SPARSEBRANDPKG)/verifyadm
 
 BIN = \
 	support \

--- a/src/pkg/manifests/system:zones:brand:sparse.p5m
+++ b/src/pkg/manifests/system:zones:brand:sparse.p5m
@@ -33,16 +33,17 @@ set name=variant.arch value=$(ARCH)
 dir  path=usr/lib
 dir  path=usr/lib/brand
 dir  path=usr/lib/brand/sparse
-file path=usr/lib/brand/sparse/config.xml mode=0644
-file path=usr/lib/brand/sparse/platform.xml mode=0644
-file path=usr/lib/brand/sparse/profile.xml mode=0644
-file path=usr/lib/brand/sparse/common.ksh mode=0755
-file path=usr/lib/brand/sparse/verifyadm mode=0755
-file path=usr/lib/brand/sparse/prestate mode=0755
-file path=usr/lib/brand/sparse/poststate mode=0755
 file path=usr/lib/brand/sparse/attach mode=0755
-file path=usr/lib/brand/sparse/detach mode=0755
 file path=usr/lib/brand/sparse/clone mode=0755
+file path=usr/lib/brand/sparse/common.ksh mode=0755
+file path=usr/lib/brand/sparse/config.xml mode=0644
+file path=usr/lib/brand/sparse/detach mode=0755
 file path=usr/lib/brand/sparse/pkgcreatezone mode=0755
+file path=usr/lib/brand/sparse/platform.xml mode=0644
+file path=usr/lib/brand/sparse/poststate mode=0755
+file path=usr/lib/brand/sparse/prestate mode=0755
+file path=usr/lib/brand/sparse/profile.xml mode=0644
+file path=usr/lib/brand/sparse/uninstall mode=0755
+file path=usr/lib/brand/sparse/verifyadm mode=0755
 license cr_Oracle license=cr_Oracle
 depend type=require fmri=system/zones/brand/ipkg@$(PKGVERS)


### PR DESCRIPTION
The diff is larger than just adding the missing script as I also re-ordered alphabetically.
Need to back-port to r151026.