### PR TITLE
Do not call "file" to determine file type

### DIFF
--- a/src/modules/portable/os_sunos.py
+++ b/src/modules/portable/os_sunos.py
@@ -20,6 +20,8 @@
 # CDDL HEADER END
 #
 # Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2017 Lauri Tirkkonen <lotheac@iki.fi>
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 #
 
 """
@@ -52,38 +54,21 @@ def get_platform():
         return arch.get_platform()
 
 def get_file_type(actions):
-        t_fd, t_path = tempfile.mkstemp()
-        t_fh = os.fdopen(t_fd, "w")
+        from pkg.flavor.smf_manifest import is_smf_manifest
         for a in actions:
-                t_fh.write(os.path.join(a.attrs[PD_LOCAL_PATH]) + "\n")
-        t_fh.close()
-        res = subprocess.Popen(["/usr/bin/file", "-f", t_path],
-            stdout=subprocess.PIPE).communicate()[0].splitlines()
-        remove(t_path)
-        assert(len(actions) == len(res))
-        for i, file_out in enumerate(res):
-                file_out = file_out.strip()
-                a = actions[i]
-                proto_file = a.attrs[PD_LOCAL_PATH]
-                colon_cnt = proto_file.count(":") + 1
-                tmp = file_out.split(":", colon_cnt)
-                res_file_name = ":".join(tmp[0:colon_cnt])
-                if res_file_name != proto_file:
-                        raise RuntimeError("pf:{0} rfn:{1} file_out:{2}".format(
-                            proto_file, res_file_name, file_out))
-                file_type = tmp[colon_cnt].strip().split()
-                joined_ft = " ".join(file_type)
-                if file_type[0] == "ELF":
-                        yield ELF
-                elif file_type[0] == "executable":
-                        yield EXEC
-                elif joined_ft == "cannot open: No such file or directory":
+                path = a.attrs['path']
+                lpath = a.attrs[PD_LOCAL_PATH]
+                try:
+                        with open(lpath, 'r') as f:
+                                magic = f.read(4)
+                except FileNotFoundError:
                         yield UNFOUND
-                elif file_type[0] == "XML":
-                        from pkg.flavor.smf_manifest import is_smf_manifest
-                        if is_smf_manifest(proto_file):
-                                yield SMF_MANIFEST
-                        else:
-                                yield joined_ft
+                        continue
+                if magic == '\x7fELF':
+                        yield ELF
+                elif magic[:2] == '#!':
+                        yield EXEC
+                elif (path.endswith('.xml') and is_smf_manifest(lpath)):
+                        yield SMF_MANIFEST
                 else:
-                        yield joined_ft
+                        yield "unknown"


### PR DESCRIPTION
This speeds up `pkgdepend` since it no longer has to fork/exec `file` for every file in the package.
Taken from Unleashed OS and modified to check all .xml files for SMF
@lotheac 