### PR TITLE
Use gcc4 for pkg objects

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -33,7 +33,7 @@ PYLINT_FMRI = pkg:/library/python-2/pylint-27
 
 CODE_WS = $$(hg root 2>/dev/null || git rev-parse --show-toplevel)
 
-CC=gcc
+CC=/opt/gcc-4.4.4/bin/gcc
 
 all := TARGET = all
 install := TARGET = install


### PR DESCRIPTION
Due to the recent changes in our gcc to support multiple lib versions, objects end up with an extra component in their runpath which causes a large number of pkg5 tests to fail.

For now, switch to building the (few) pkg5 objects with gcc4 which does not have this additional library path.

We'll have to resolve this eventually, probably by changing the tests.