### PR TITLE
further restrict the privileges of package depot services

### DIFF
--- a/src/svc/pkg-server.xml
+++ b/src/svc/pkg-server.xml
@@ -83,7 +83,15 @@
 		type='method'
 		name='start'
 		exec='%{pkg/pkg_root}/lib/svc/method/svc-pkg-server %m'
-		timeout_seconds='0' />
+		timeout_seconds='0'>
+		<method_context security_flags='aslr'>
+			<method_credential
+                            user='pkg5srv'
+                            group='pkg5srv'
+                            privileges='basic,!file_link_any,!proc_info,!proc_session'
+			/>
+		</method_context>
+	</exec_method>
 
 	<exec_method
 		type='method'

--- a/src/svc/svc-pkg-mdns
+++ b/src/svc/svc-pkg-mdns
@@ -51,7 +51,7 @@ case "$1" in
 
 	# adjust the PYTHONPATH to point to the current environment
 	# we need to make sure to adjust the PYTHONPATH accordingly
-	# to a Python 2.7 or 3.4 environment
+	# to a Python 2 or 3 environment
 	python_ver=$(head -1 ${pkg_root}usr/lib/pkg.depotd 2>/dev/null |
 	    awk -F/ '{print $NF}')
 	if [[ $python_ver != *python* ]]; then

--- a/src/svc/svc-pkg-server
+++ b/src/svc/svc-pkg-server
@@ -64,7 +64,7 @@ case "$1" in
 
 	# adjust the PYTHONPATH to point to the current environment
 	# we need to make sure to adjust the PYTHONPATH accordingly
-	# to a Python 2.7 or 3.4 environment
+	# to a Python 2 or 3 environment
 	python_ver=$(head -1 ${pkg_root}usr/lib/pkg.depotd 2>/dev/null |
 	    awk -F/ '{print $NF}')
 	if [[ $python_ver != *python* ]]; then


### PR DESCRIPTION
The `pkg/server` services do not need to run as root, nor with a full set of normal user privileges.
This change also enables ASLR.

```
omniosce# ps -ef | grep depo
 pkg5srv 11620  1140   0 14:22:57 ?           0:00 /usr/bin/python2.7 /usr/lib/pkg.depotd --cfg svc:/application/pkg/server:r15102
...

omniosce# ppriv -v 11620
11620:  /usr/bin/python2.7 /usr/lib/pkg.depotd --cfg svc:/application/pkg/serv
flags = <none>
        E: file_read,file_write,net_access,proc_exec,proc_fork,proc_secflags
        I: file_read,file_write,net_access,proc_exec,proc_fork,proc_secflags
        P: file_read,file_write,net_access,proc_exec,proc_fork,proc_secflags
        L: file_read,file_write,net_access,proc_exec,proc_fork,proc_secflags

omniosce# psecflags 11620
11620:  /usr/bin/python2.7 /usr/lib/pkg.depotd --cfg svc:/application/pkg/serv
        E:      aslr
        I:      aslr
        L:      none
        U:      aslr,forbidnullmap,noexecstack
```