### PR TITLE
pkg verify parsable output and unpackaged contents reporting

### DIFF
--- a/doc/client_api_versions.txt
+++ b/doc/client_api_versions.txt
@@ -1,3 +1,59 @@
+Version 83:
+Compatible with clients using versions 72-82.
+
+    pkg.client.api.ImageInterface has changed as follows:
+        * Introduced new non-linked image interfaces:
+                gen_plan_verify()
+
+        * Changed methods:
+                add_item_message()
+                extend_item_messages()
+                gen_item_messages()
+
+        * Added method:
+                get_parsable_item_messages()
+
+Version 82:
+Compatible with clients using versions 72-81.
+
+    pkg.client.api.PackageInfo has changed as follows:
+        * added a new field 'last_install' to record the package last install time
+        * added a new field 'last_update' to record the package last update time
+
+Version 81:
+Compatible with clients using versions 72-80.
+
+    pkg.client.api.ImageInterface has changed as follows:
+        * Introduced new non-linked image interfaces:
+                gen_plan_dehydrate()
+                gen_plan_rehydrate()
+                gen_plan_fix()
+
+        * Added a new function to get the list of dehydrated publishers:
+                get_dehydrated_publishers()
+
+    pkg.client.api_errors has changed as follows:
+        * Added a no_repo_pubs property to PlanCreationException
+          that contains a list of publishers that have no package
+          repository configured.
+
+    pkg.client.api.PlanDescription has changed as follows:
+        * Added methods:
+                add_item_message()
+                extend_item_messages()
+                gen_item_messages()
+
+    pkg.client.progress has changed as follows:
+        * Removed methods from ProgressTracker:
+                verify_start()
+                verify_start_pkg()
+                verify_add_progress()
+                verify_yield_error()
+                verify_yield_warning()
+                verify_yield_info()
+                verify_end_pkg()
+                verify_done()
+
 Version 80:
 Compatible with clients using versions 72-79.
 

--- a/src/client.py
+++ b/src/client.py
@@ -103,7 +103,7 @@ except KeyboardInterrupt:
         import sys
         sys.exit(1)
 
-CLIENT_API_VERSION = 82
+CLIENT_API_VERSION = 83
 PKG_CLIENT_NAME = "pkg"
 
 JUST_UNKNOWN = 0
@@ -281,12 +281,14 @@ def usage(usage_error=None, cmd=None, retcode=EXIT_BADOPT, full=False,
         adv_usage["search"] = _(
             "[-HIaflpr] [-o attribute ...] [-s repo_uri] query")
 
-        adv_usage["verify"] = _("[-Hqv] [pkg_fmri_pattern ...]")
+        adv_usage["verify"] = _("[-Hqv] [--parsable version] [--unpackaged]\n"
+            "            [--unpackaged-only] [pkg_fmri_pattern ...]")
         adv_usage["fix"] = _(
             "[-Hnvq] [--no-be-activate]\n"
             "            [--no-backup-be | --require-backup-be] [--backup-be-name name]\n"
             "            [--deny-new-be | --require-new-be] [--be-name name]\n"
-            "            [--accept] [--licenses] [pkg_fmri_pattern ...]")
+            "            [--accept] [--licenses] [--parsable version] [--unpackaged]\n"
+            "            [pkg_fmri_pattern ...]")
         adv_usage["revert"] = _(
             "[-nv] [--no-be-activate]\n"
             "            [--no-backup-be | --require-backup-be] [--backup-be-name name]\n"
@@ -1022,6 +1024,7 @@ def __display_parsable_plan(api_inst, parsable_version, child_images=None):
         mediators_changed = []
         editables_changed = []
         pkg_actuators = {}
+        item_messages = {}
         licenses = []
         if child_images is None:
                 child_images = []
@@ -1098,6 +1101,7 @@ def __display_parsable_plan(api_inst, parsable_version, child_images=None):
                             (str(dfmri), src_tup, dest_tup))
                         api_inst.set_plan_license_status(dfmri, dest_li.license,
                             displayed=True)
+                item_messages = plan.get_parsable_item_messages()
 
         ret = {
             "activate-be": be_activated,
@@ -1116,6 +1120,7 @@ def __display_parsable_plan(api_inst, parsable_version, child_images=None):
             "create-backup-be": backup_be_created,
             "create-new-be": new_be_created,
             "image-name": None,
+            "item-messages": item_messages,
             "licenses": sorted(licenses, key=lambda x: (x[0], x[1], x[2])),
             "release-notes": release_notes,
             "remove-packages": sorted(removed_fmris),
@@ -1208,7 +1213,6 @@ def display_plan(api_inst, child_image_plans, noexecute, omit_headers, op,
                 last_item_id = None
                 for item_id, msg_time, msg_type, msg_text in \
                     plan.gen_item_messages(ordered=True):
-
                         ntd = api_inst.planned_nothingtodo(li_ignore_all=True)
                         if last_item_id is None or last_item_id != item_id:
                                 last_item_id = item_id
@@ -1235,10 +1239,80 @@ def display_plan(api_inst, child_image_plans, noexecute, omit_headers, op,
 
                         msg(msg_text)
 
+def __print_verify_result(op, api_inst, plan, noexecute, omit_headers,
+    verbose, print_packaged=True):
+        did_print_something = False
+        if print_packaged:
+                last_item_id = None
+                ntd = api_inst.planned_nothingtodo(li_ignore_all=True)
+                for item_id, parent_id, msg_time, msg_level, msg_type, \
+                    msg_text in plan.gen_item_messages(ordered=True):
+                        if msg_type == MSG_UNPACKAGED:
+                                continue
+                        if parent_id is None and last_item_id != item_id:
+                                if op == PKG_OP_FIX and not noexecute and \
+                                    msg_level == MSG_ERROR:
+                                        if ntd:
+                                                msg(_("Could not repair: {0:50}"
+                                                    ).format(item_id))
+                                        else:
+                                                msg(_("Repairing: {0:50}"
+                                                    ).format(item_id))
+
+                        if op in [PKG_OP_FIX, PKG_OP_VERIFY]:
+                                if not verbose and msg_level == MSG_INFO:
+                                        # If verbose is False, don't display
+                                        # any INFO messages.
+                                        continue
+
+                                if not omit_headers:
+                                        omit_headers = True
+                                        msg(_("{pkg_name:70} {result:>7}"
+                                            ).format(pkg_name=_("PACKAGE"),
+                                            result=_("STATUS")))
+
+                        # Top level message.
+                        if not parent_id:
+                                msg(msg_text)
+                        elif item_id == "overlay_errors":
+                                msg(_("\t{0}").format(msg_text))
+                        elif last_item_id != item_id:
+                                # A new action id; we need to print it out and
+                                # then group its subsequent messages.
+                                msg(_("\t{0}\n\t\t{1}").format(item_id,
+                                    msg_text))
+                        else:
+                                msg(_("\t\t{0}").format(msg_text))
+                        last_item_id = item_id
+                        did_print_something = True
+        else:
+                if not omit_headers:
+                        msg(_("UNPACKAGED CONTENTS"))
+
+                # Print warning messages at the beginning.
+                for item_id, parent_id, msg_time, msg_level, msg_type, \
+                    msg_text in plan.gen_item_messages():
+                        if msg_type != MSG_UNPACKAGED:
+                                continue
+                        if msg_level == MSG_WARNING:
+                                msg(_("WARNING: {0}").format(msg_text))
+                # Print the rest of messages.
+                for item_id, parent_id, msg_time, msg_level, msg_type, \
+                    msg_text in plan.gen_item_messages(ordered=True):
+                        if msg_type != MSG_UNPACKAGED:
+                                continue
+                        if msg_level == MSG_INFO:
+                                msg(_("{0}:\n\t{1}").format(
+                                    item_id, msg_text))
+                        elif msg_level == MSG_ERROR:
+                                msg(_("ERROR: {0}").format(msg_text))
+                        did_print_something = True
+        return did_print_something
+
 def display_plan_cb(api_inst, child_image_plans=None, noexecute=False,
     omit_headers=False, op=None, parsable_version=None, quiet=False,
     quiet_plan=False, show_licenses=False, stage=None, verbose=None,
-    get_parsable_plan_cb=None, plan_only=False):
+    unpackaged=False, unpackaged_only=False, plan_only=False):
         """Callback function for displaying plan."""
 
         if plan_only:
@@ -1266,7 +1340,7 @@ def display_plan_cb(api_inst, child_image_plans=None, noexecute=False,
                         s += " ({0})".format(api_inst.get_linked_name())
                 msg(s)
 
-                if op != PKG_OP_FIX or not verbose:
+                if op not in [PKG_OP_FIX, PKG_OP_VERIFY] or not verbose:
                         # Even nothingtodo, but need to continue to display INFO
                         # message if verbose is True.
                         return
@@ -1277,9 +1351,9 @@ def display_plan_cb(api_inst, child_image_plans=None, noexecute=False,
         if not quiet and not quiet_plan:
                 __display_plan(api_inst, verbose, noexecute, op=op)
 
-        if parsable_version is not None and get_parsable_plan_cb:
-                parsable_plan = get_parsable_plan_cb(api_inst,
-                    parsable_version, child_image_plans)
+        if parsable_version is not None:
+                parsable_plan = plan.get_parsable_plan(parsable_version,
+                    child_image_plans, api_inst=api_inst)
                 logger.info(json.dumps(parsable_plan))
         elif not quiet:
                 if not quiet_plan:
@@ -1287,35 +1361,21 @@ def display_plan_cb(api_inst, child_image_plans=None, noexecute=False,
                         # output.
                         msg()
 
-                last_item_id = None
-                for item_id, msg_time, msg_type, msg_text in \
-                    plan.gen_item_messages(ordered=True):
+                # Message print for package verification result.
+                if not unpackaged_only:
+                        did_print = __print_verify_result(op, api_inst, plan,
+                            noexecute, omit_headers, verbose)
 
-                        ntd = api_inst.planned_nothingtodo(li_ignore_all=True)
-                        if last_item_id is None or last_item_id != item_id:
-                                last_item_id = item_id
-                                if op == PKG_OP_FIX and not noexecute and \
-                                    msg_type == MSG_ERROR:
-                                        if ntd:
-                                                msg(_("Could not repair: {0:50}"
-                                                    ).format(item_id))
-                                        else:
-                                                msg(_("Repairing: {0:50}"
-                                                    ).format(item_id))
+                        # Print an extra line to separate output between
+                        # packaged and unpackaged content.
+                        if did_print and unpackaged and any(entry[4] ==
+                            MSG_UNPACKAGED for entry in
+                            plan.gen_item_messages()):
+                                msg("".join(["-"] * 80))
 
-                        if op == PKG_OP_FIX:
-                                if not verbose and msg_type == MSG_INFO:
-                                        # If verbose is False, don't display
-                                        # any INFO messages.
-                                        continue
-
-                                if not omit_headers:
-                                        omit_headers = True
-                                        msg(_("{pkg_name:70} {result:>7}").format(
-                                            pkg_name=_("PACKAGE"),
-                                            result=_("STATUS")))
-
-                        msg(msg_text)
+                if unpackaged or unpackaged_only:
+                        __print_verify_result(op, api_inst, plan, noexecute,
+                            omit_headers, verbose, print_packaged=False)
 
 def __api_prepare_plan(operation, api_inst):
         """Prepare plan."""
@@ -2392,6 +2452,23 @@ def uninstall(op, api_inst, pargs,
 
         return __handle_client_json_api_output(out_json, op)
 
+def verify(op, api_inst, pargs, omit_headers, parsable_version, quiet, verbose,
+    unpackaged, unpackaged_only):
+        """Determine if installed packages match manifests."""
+
+        out_json = client_api._verify(op, api_inst, pargs, omit_headers,
+            parsable_version, quiet, verbose, unpackaged, unpackaged_only,
+            display_plan_cb=display_plan_cb, logger=logger)
+
+        # Print error messages.
+        if "errors" in out_json:
+                _generate_error_messages(out_json["status"],
+                    out_json["errors"], cmd=op)
+
+        # Since the verify output has been handled by display_plan_cb, only
+        # status code needs to be returned.
+        return out_json["status"]
+
 def revert(op, api_inst, pargs,
     backup_be, backup_be_name, be_activate, be_name, new_be, noexecute,
     parsable_version, quiet, tagged, verbose):
@@ -2420,21 +2497,20 @@ def rehydrate(op, api_inst, pargs, noexecute, publishers, quiet, verbose):
 
 def fix(op, api_inst, pargs, accept, backup_be, backup_be_name, be_activate,
     be_name, new_be, noexecute, omit_headers, parsable_version, quiet,
-    show_licenses, verbose):
+    show_licenses, verbose, unpackaged):
         """Fix packaging errors found in the image."""
 
-        return __api_op(op, api_inst, args=pargs, _accept=accept,
-            _noexecute=noexecute, _omit_headers=omit_headers, _quiet=quiet,
-            _show_licenses=show_licenses, _verbose=verbose, backup_be=backup_be,
-            backup_be_name=backup_be_name, be_activate=be_activate,
-            be_name=be_name, new_be=new_be, _parsable_version=parsable_version)
+        out_json = client_api._fix(op, api_inst, pargs, accept, backup_be,
+            backup_be_name, be_activate, be_name, new_be, noexecute,
+            omit_headers, parsable_version, quiet, show_licenses, verbose,
+            unpackaged, display_plan_cb=display_plan_cb, logger=logger)
 
-def verify(op, api_inst, pargs, omit_headers, parsable_version, quiet, verbose):
-        """Determine if installed packages match manifests."""
+        # Print error messages.
+        if "errors" in out_json:
+                _generate_error_messages(out_json["status"],
+                    out_json["errors"], cmd=op)
 
-        return __api_op(PKG_OP_FIX, api_inst, args=pargs, _noexecute=True,
-            _omit_headers=omit_headers, _quiet=quiet, _quiet_plan=True,
-            _verbose=verbose, _parsable_version=parsable_version)
+        return out_json["status"]
 
 def list_mediators(op, api_inst, pargs, omit_headers, output_format,
     list_available):
@@ -5246,6 +5322,10 @@ opts_mapping = {
     "omit_headers" :      ("H",  ""),
 
     "update_index" :      ("",  "no-index"),
+
+    "unpackaged" :        ("",  "unpackaged"),
+
+    "unpackaged_only" :        ("",  "unpackaged-only"),
 
     "refresh_catalogs" :  ("",  "no-refresh"),
 

--- a/src/client.py
+++ b/src/client.py
@@ -1175,16 +1175,15 @@ def display_plan(api_inst, child_image_plans, noexecute, omit_headers, op,
                 return
 
         if not quiet and parsable_version is None and \
-            api_inst.planned_nothingtodo(li_ignore_all=True):
-                if not quiet_plan:
-                        # nothing todo
-                        if op == PKG_OP_UPDATE:
-                                s = _("No updates available for this image.")
-                        else:
-                                s = _("No updates necessary for this image.")
-                        if api_inst.ischild():
-                                s += " ({0})".format(api_inst.get_linked_name())
-                        msg(s)
+            api_inst.planned_nothingtodo(li_ignore_all=True) and not quiet_plan:
+                # nothing todo
+                if op == PKG_OP_UPDATE:
+                        s = _("No updates available for this image.")
+                else:
+                        s = _("No updates necessary for this image.")
+                if api_inst.ischild():
+                        s += " ({0})".format(api_inst.get_linked_name())
+                msg(s)
 
                 if op != PKG_OP_FIX or not verbose:
                         # Even nothingtodo, but need to continue to display INFO
@@ -1210,24 +1209,29 @@ def display_plan(api_inst, child_image_plans, noexecute, omit_headers, op,
                 for item_id, msg_time, msg_type, msg_text in \
                     plan.gen_item_messages(ordered=True):
 
+                        ntd = api_inst.planned_nothingtodo(li_ignore_all=True)
                         if last_item_id is None or last_item_id != item_id:
                                 last_item_id = item_id
-                                if not noexecute and op == PKG_OP_FIX and \
+                                if op == PKG_OP_FIX and not noexecute and \
                                     msg_type == MSG_ERROR:
-                                        msg(_("Repairing: {0:50}").format(
-                                            item_id))
+                                        if ntd:
+                                                msg(_("Could not repair: {0:50}"
+                                                    ).format(item_id))
+                                        else:
+                                                msg(_("Repairing: {0:50}"
+                                                    ).format(item_id))
 
-                        if op == PKG_OP_FIX and not verbose and \
-                            msg_type == MSG_INFO:
-                                # If verbose is False, don't display any INFO
-                                # messages.
-                                continue
+                        if op == PKG_OP_FIX:
+                                if not verbose and msg_type == MSG_INFO:
+                                        # If verbose is False, don't display
+                                        # any INFO messages.
+                                        continue
 
-                        if not omit_headers:
-                                omit_headers = True
-                                msg(_("{pkg_name:70} {result:>7}").format(
-                                    pkg_name=_("PACKAGE"),
-                                    result=_("STATUS")))
+                                if not omit_headers:
+                                        omit_headers = True
+                                        msg(_("{pkg_name:70} {result:>7}").format(
+                                            pkg_name=_("PACKAGE"),
+                                            result=_("STATUS")))
 
                         msg(msg_text)
 
@@ -1252,16 +1256,15 @@ def display_plan_cb(api_inst, child_image_plans=None, noexecute=False,
                 return
 
         if not quiet and parsable_version is None and \
-            api_inst.planned_nothingtodo(li_ignore_all=True):
-                if not quiet_plan:
-                        # nothing todo
-                        if op == PKG_OP_UPDATE:
-                                s = _("No updates available for this image.")
-                        else:
-                                s = _("No updates necessary for this image.")
-                        if api_inst.ischild():
-                                s += " ({0})".format(api_inst.get_linked_name())
-                        msg(s)
+            api_inst.planned_nothingtodo(li_ignore_all=True) and not quiet_plan:
+                # nothing todo
+                if op == PKG_OP_UPDATE:
+                        s = _("No updates available for this image.")
+                else:
+                        s = _("No updates necessary for this image.")
+                if api_inst.ischild():
+                        s += " ({0})".format(api_inst.get_linked_name())
+                msg(s)
 
                 if op != PKG_OP_FIX or not verbose:
                         # Even nothingtodo, but need to continue to display INFO
@@ -1288,24 +1291,29 @@ def display_plan_cb(api_inst, child_image_plans=None, noexecute=False,
                 for item_id, msg_time, msg_type, msg_text in \
                     plan.gen_item_messages(ordered=True):
 
+                        ntd = api_inst.planned_nothingtodo(li_ignore_all=True)
                         if last_item_id is None or last_item_id != item_id:
                                 last_item_id = item_id
-                                if not noexecute and op == PKG_OP_FIX and \
+                                if op == PKG_OP_FIX and not noexecute and \
                                     msg_type == MSG_ERROR:
-                                        msg(_("Repairing: {0:50}").format(
-                                            item_id))
+                                        if ntd:
+                                                msg(_("Could not repair: {0:50}"
+                                                    ).format(item_id))
+                                        else:
+                                                msg(_("Repairing: {0:50}"
+                                                    ).format(item_id))
 
-                        if op == PKG_OP_FIX and not verbose and \
-                            msg_type == MSG_INFO:
-                                # If verbose is False, don't display any INFO
-                                # messages.
-                                continue
+                        if op == PKG_OP_FIX:
+                                if not verbose and msg_type == MSG_INFO:
+                                        # If verbose is False, don't display
+                                        # any INFO messages.
+                                        continue
 
-                        if not omit_headers:
-                                omit_headers = True
-                                msg(_("{pkg_name:70} {result:>7}").format(
-                                    pkg_name=_("PACKAGE"),
-                                    result=_("STATUS")))
+                                if not omit_headers:
+                                        omit_headers = True
+                                        msg(_("{pkg_name:70} {result:>7}").format(
+                                            pkg_name=_("PACKAGE"),
+                                            result=_("STATUS")))
 
                         msg(msg_text)
 
@@ -1752,6 +1760,16 @@ def __api_plan_delete(api_inst):
         except OSError as e:
                 raise api_errors._convert_error(e)
 
+def _verify_exit_code(api_inst):
+        """Determine the exit code of pkg verify, which should be based on
+        whether we find errors."""
+
+        plan = api_inst.describe()
+        for item_id, msg_time, msg_type, msg_text in plan.gen_item_messages():
+                if msg_type == MSG_ERROR:
+                        return EXIT_OOPS
+        return EXIT_OK
+
 def __api_op(_op, _api_inst, _accept=False, _li_ignore=None, _noexecute=False,
     _omit_headers=False, _origins=None, _parsable_version=None, _quiet=False,
     _quiet_plan=False, _review_release_notes=False, _show_licenses=False,
@@ -1784,6 +1802,9 @@ def __api_op(_op, _api_inst, _accept=False, _li_ignore=None, _noexecute=False,
                         # consumer from creating a noop plan and then
                         # preparing and executing it.)
                         __api_plan_save(_api_inst)
+                # for pkg verify
+                if _op == PKG_OP_FIX and _noexecute and _quiet_plan:
+                        return _verify_exit_code(_api_inst)
                 if _api_inst.planned_nothingtodo():
                         return EXIT_NOP
                 if _noexecute or _stage == API_STAGE_PLAN:
@@ -2411,18 +2432,9 @@ def fix(op, api_inst, pargs, accept, backup_be, backup_be_name, be_activate,
 def verify(op, api_inst, pargs, omit_headers, parsable_version, quiet, verbose):
         """Determine if installed packages match manifests."""
 
-        rval = __api_op(PKG_OP_FIX, api_inst, args=pargs, _noexecute=True,
+        return __api_op(PKG_OP_FIX, api_inst, args=pargs, _noexecute=True,
             _omit_headers=omit_headers, _quiet=quiet, _quiet_plan=True,
             _verbose=verbose, _parsable_version=parsable_version)
-
-        if rval == EXIT_NOP:
-                # Nothing to fix.
-                return EXIT_OK
-        elif rval == EXIT_OK:
-                # Fixes to image required.
-                return EXIT_OOPS
-        else:
-                return rval
 
 def list_mediators(op, api_inst, pargs, omit_headers, output_format,
     list_available):

--- a/src/man/pkg.1
+++ b/src/man/pkg.1
@@ -1,5 +1,5 @@
 '\" te
-.\" Copyright (c) 2007, 2014, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
 .\" Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 .TH pkg 1 "19 Jun 2018" "SunOS 5.11" "User Commands"
 .SH NAME
@@ -103,7 +103,8 @@ pkg \- Image Packaging System retrieval client
 
 .LP
 .nf
-/usr/bin/pkg verify [-Hqv] [\fIpkg_fmri_pattern\fR ...]
+/usr/bin/pkg verify [-Hqv] [--parsable \fIversion\fR]
+    [--unpackaged] [--unpackaged-only] [\fIpkg_fmri_pattern\fR ...]
 .fi
 
 .LP
@@ -112,7 +113,8 @@ pkg \- Image Packaging System retrieval client
     [--no-backup-be | --require-backup-be]
     [--backup-be-name \fIname\fR]
     [--deny-new-be | --require-new-be] [--be-name \fIname\fR]
-    [--accept] [--licenses] [\fIpkg_fmri_pattern\fR ...]
+    [--accept] [--licenses] [--parsable \fIversion\fR] [--unpackaged]
+    [\fIpkg_fmri_pattern\fR ...]
 .fi
 
 .LP
@@ -1515,7 +1517,7 @@ With the \fB-a\fR option (and by default), searching for \fBtoken\fR results in 
 .ne 2
 .mk
 .na
-\fB\fBpkg verify\fR [\fB-Hqv\fR] [\fIpkg_fmri_pattern\fR ...]\fR
+\fBpkg verify\fR [\fB-Hqv\fR] [--parsable \fBversion\fR] [--unpackaged] [--unpackaged-only] [\fIpkg_fmri_pattern\fR ...]
 .ad
 .sp .6
 .RS 4n
@@ -1535,7 +1537,7 @@ Validate the installation of only the specified packages installed in the curren
 .ne 2
 .mk
 .na
-\fB\fB-H\fR\fR
+\fB-H\fR
 .ad
 .sp .6
 .RS 4n
@@ -1546,7 +1548,19 @@ Omit the headers from the verification output.
 .ne 2
 .mk
 .na
-\fB\fB-q\fR\fR
+\fB--parsable version\fR
+.ad
+.sp .6
+.RS 4n
+Parsable output; the supported version is 0. Use of this option implies
+\fB-q\fR.
+.RE
+
+.sp
+.ne 2
+.mk
+.na
+\fB-q\fR
 .ad
 .sp .6
 .RS 4n
@@ -1557,7 +1571,29 @@ Suppress progress messages and all other output during the requested operation.
 .ne 2
 .mk
 .na
-\fB\fB-v\fR\fR
+\fB--unpackaged\fR
+.ad
+.sp .6
+.RS 4n
+Report unpackaged contents in addition to general output.
+.RE
+
+.sp
+.ne 2
+.mk
+.na
+\fB--unpackaged-only\fR
+.ad
+.sp .6
+.RS 4n
+Report only unpackaged contents.
+.RE
+
+.sp
+.ne 2
+.mk
+.na
+\fB-v\fR
 .ad
 .sp .6
 .RS 4n
@@ -1570,7 +1606,7 @@ Include informational messages regarding packages.
 .ne 2
 .mk
 .na
-\fB\fBpkg fix\fR [\fB-nvq\fR] [\fB--no-be-activate\fR] [\fB--no-backup-be\fR | \fB--require-backup-be\fR] [\fB--backup-be-name\fR \fIname\fR] [\fB--deny-new-be\fR | \fB--require-new-be\fR] [\fB--be-name\fR \fIname\fR] [\fB--accept\fR] [\fB--licenses\fR] [\fIpkg_fmri_pattern\fR ...]\fR
+\fBpkg fix\fR [\fB-nvq\fR] [\fB--no-be-activate\fR] [\fB--no-backup-be\fR | \fB--require-backup-be\fR] [\fB--backup-be-name\fR \fIname\fR] [\fB--deny-new-be\fR | \fB--require-new-be\fR] [\fB--be-name\fR \fIname\fR] [\fB--accept\fR] [\fB--licenses\fR] [\fB--parsable\fR <version>] [\fB--unpackaged\fR] [\fIpkg_fmri_pattern\fR ...]
 .ad
 .sp .6
 .RS 4n
@@ -1590,7 +1626,7 @@ Fix errors reported by \fBpkg verify\fR for only the specified packages installe
 .ne 2
 .mk
 .na
-\fB\fB--accept\fR\fR
+\fB--accept\fR
 .ad
 .sp .6
 .RS 4n
@@ -1601,11 +1637,34 @@ Indicate that you agree to and accept the terms of the licenses of the packages 
 .ne 2
 .mk
 .na
-\fB\fB--licenses\fR\fR
+\fB--licenses\fR
 .ad
 .sp .6
 .RS 4n
 Display all of the licenses for the packages that are installed or updated as part of this operation. For updated packages, display the license only if the license has changed.
+.RE
+
+.sp
+.ne 2
+.mk
+.na
+\fB--parsable <version>\fR
+.ad
+.sp .6
+.RS 4n
+Parsable output; the supported version is 0. Use of this option implies
+\fB-q\fR.
+.RE
+
+.sp
+.ne 2
+.mk
+.na
+\fB--unpackaged\fR
+.ad
+.sp .6
+.RS 4n
+Report unpackaged contents in addition to general output.
 .RE
 
 For all other options, see the \fBinstall\fR command above.

--- a/src/modules/client/api.py
+++ b/src/modules/client/api.py
@@ -113,9 +113,9 @@ from pkg.smf import NonzeroExitException
 # things like help(pkg.client.api.PlanDescription)
 from pkg.client.plandesc import PlanDescription # pylint: disable=W0611
 
-CURRENT_API_VERSION = 82
+CURRENT_API_VERSION = 83
 COMPATIBLE_API_VERSIONS = frozenset([72, 73, 74, 75, 76, 77, 78, 79, 80, 81,
-    CURRENT_API_VERSION])
+    82, CURRENT_API_VERSION])
 CURRENT_P5I_VERSION = 1
 
 # Image type constants.
@@ -1444,7 +1444,7 @@ in the environment or by setting simulate_cmdpath in DebugValues.""")
                 if _li_md_only:
                         _refresh_catalogs = _update_index = False
                 if _op in [API_OP_DETACH, API_OP_SET_MEDIATOR, API_OP_FIX,
-                    API_OP_DEHYDRATE, API_OP_REHYDRATE]:
+                    API_OP_VERIFY, API_OP_DEHYDRATE, API_OP_REHYDRATE]:
                         # these operations don't change fmris and don't need
                         # to recurse, so disable a bunch of linked image
                         # operations.
@@ -1513,7 +1513,7 @@ in the environment or by setting simulate_cmdpath in DebugValues.""")
                         elif _op == API_OP_INSTALL or \
                             _op == API_OP_EXACT_INSTALL:
                                 self._img.make_install_plan(**kwargs)
-                        elif _op == API_OP_FIX:
+                        elif _op in [API_OP_FIX, API_OP_VERIFY]:
                                 self._img.make_fix_plan(**kwargs)
                         elif _op == API_OP_REHYDRATE:
                                 self._img.make_rehydrate_plan(**kwargs)
@@ -2318,8 +2318,8 @@ in the environment or by setting simulate_cmdpath in DebugValues.""")
                     _refresh_catalogs=False, _update_index=False,
                     publishers=publishers)
 
-        def gen_plan_fix(self, args, backup_be=None, backup_be_name=None,
-            be_activate=True, be_name=None, new_be=None, noexecute=True):
+        def gen_plan_verify(self, args, noexecute=True, unpackaged=False,
+            unpackaged_only=False):
                 """This is a generator function that yields a PlanDescription
                 object.
 
@@ -2328,19 +2328,34 @@ in the environment or by setting simulate_cmdpath in DebugValues.""")
                 and then execute_plan().  After execution of a plan, or to
                 abandon a plan, reset() should be called.
 
-                'show_licenses' indicates whether we should display all licenses.
+                For parameters, refer to the 'gen_plan_install'
+                function for an explanation of their usage and effects."""
 
-                'accept' indicates whether we agree to and accept the terms
-                of the licenses.
+                op = API_OP_VERIFY
+                return self.__plan_op(op, args=args, _noexecute=noexecute,
+                    _refresh_catalogs=False, _update_index=False,
+                    unpackaged=unpackaged, unpackaged_only=unpackaged_only)
 
-                For all other parameters, refer to the 'gen_plan_install'
+        def gen_plan_fix(self, args, backup_be=None, backup_be_name=None,
+            be_activate=True, be_name=None, new_be=None, noexecute=True,
+            unpackaged=False):
+                """This is a generator function that yields a PlanDescription
+                object.
+
+                Plan to repair anything that fails to verify. Once an operation
+                has been planned, it may be executed by first calling prepare(),
+                and then execute_plan().  After execution of a plan, or to
+                abandon a plan, reset() should be called.
+
+                For parameters, refer to the 'gen_plan_install'
                 function for an explanation of their usage and effects."""
 
                 op = API_OP_FIX
                 return self.__plan_op(op, args=args, _be_activate=be_activate,
                     _backup_be=backup_be, _backup_be_name=backup_be_name,
                     _be_name=be_name, _new_be=new_be, _noexecute=noexecute,
-                    _refresh_catalogs=False, _update_index=False)
+                    _refresh_catalogs=False, _update_index=False,
+                    unpackaged=unpackaged)
 
         def attach_linked_child(self, lin, li_path, li_props=None,
             accept=False, allow_relink=False, force=False, li_md_only=False,

--- a/src/modules/client/api_errors.py
+++ b/src/modules/client/api_errors.py
@@ -3253,7 +3253,7 @@ class InvalidOptionError(ApiException):
                             op2=self.options[1])
                         if self.valid_args:
                                 s += _("\nSupported: {0}").format(", ".join(
-                                    self.valid_args))
+                                    [str(va) for va in self.valid_args]))
                         return s
                 elif self.err_type == self.INCOMPAT:
                         assert len(self.options) == 2

--- a/src/modules/client/bootenv.py
+++ b/src/modules/client/bootenv.py
@@ -20,10 +20,11 @@
 # CDDL HEADER END
 #
 
-# Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
 
 import errno
 import os
+import shutil
 import tempfile
 
 from pkg.client import global_settings
@@ -261,12 +262,49 @@ class BootEnv(object):
                     bee.get("space_used"), bee.get("date"))
 
         @staticmethod
+        def copy_be(src_be_name, dst_be_name):
+                ret, be_name_clone, not_used = be.beCopy(
+                    dst_bename=dst_be_name,
+                    src_bename=src_be_name)
+                if ret != 0:
+                        raise api_errors.UnableToCopyBE()
+
+        @staticmethod
         def rename_be(orig_name, new_name):
                 return be.beRename(orig_name, new_name)
 
         @staticmethod
         def destroy_be(be_name):
                 return be.beDestroy(be_name, 1, True)
+
+        @staticmethod
+        def cleanup_be(be_name):
+                be_list = BootEnv.get_be_list()
+                for elem in be_list:
+                        if "orig_be_name" in elem and be_name == \
+                            elem["orig_be_name"]:
+                                # Force unmount the be and destroy it.
+                                # Ignore errors.
+                                try:
+                                        if elem.get("mounted"):
+                                                BootEnv.unmount_be(
+                                                    be_name, force=True)
+                                                shutil.rmtree(elem.get(
+                                                    "mountpoint"),
+                                                    ignore_errors=True)
+                                        BootEnv.destroy_be(
+                                            be_name)
+                                except Exception as e:
+                                            pass
+                                break
+
+        @staticmethod
+        def mount_be(be_name, mntpt, include_bpool=False):
+                return be.beMount(be_name, mntpt, include_bpool=include_bpool)
+
+        @staticmethod
+        def unmount_be(be_name, force=False):
+                return be.beUnmount(be_name, force=force)
 
         @staticmethod
         def set_default_be(be_name):
@@ -717,12 +755,28 @@ class BootEnvNull(object):
                 return None
 
         @staticmethod
+        def copy_be(src_be_name, dst_be_name):
+                pass
+
+        @staticmethod
         def rename_be(orig_name, new_name):
-	        pass
+                pass
 
         @staticmethod
         def destroy_be(be_name):
-	        pass
+                pass
+
+        @staticmethod
+        def cleanup_be(be_name):
+                pass
+
+        @staticmethod
+        def mount_be(be_name, mntpt, include_bpool=False):
+                return None
+
+        @staticmethod
+        def unmount_be(be_name, force=False):
+                return None
 
         @staticmethod
         def set_default_be(be_name):

--- a/src/modules/client/client_api.py
+++ b/src/modules/client/client_api.py
@@ -71,7 +71,7 @@ from pkg.client.debugvalues import DebugValues
 from pkg.client.pkgdefs import *
 from pkg.misc import EmptyI, msg, emsg, PipeError
 
-CLIENT_API_VERSION = 82
+CLIENT_API_VERSION = 83
 PKG_CLIENT_NAME = "pkg"
 pkg_timer = pkg.misc.Timer("pkg client")
 SYSREPO_HIDDEN_URI = "<system-repository>"
@@ -177,6 +177,15 @@ def __pkg_list_output_schema():
         return data_schema
 
 def __get_plan_props():
+        msg_payload_item = {
+            "type": "object",
+            "properties": {
+                "msg_time": {"type": ["null", "string"]},
+                "msg_level": {"type": ["null", "string"]},
+                "msg_type": {"type": ["null", "string"]},
+                "msg_text": {"type": ["null", "string"]}
+            }
+        }
         plan_props = {"type": "object",
             "properties": {
                 "image-name": {"type": ["null", "string"]},
@@ -283,6 +292,20 @@ def __get_plan_props():
                 },
                 "activate-be": {
                   "type": ["null", "boolean"],
+                },
+                # Because item id is non-deterministic, only properties that
+                # can be determined are listed here.
+                "item-messages": {"type": "object",
+                    "properties": {
+                        "unpackaged": {"type": "object",
+                            "properties": {
+                                "errors": {"type": "array",
+                                                "items": msg_payload_item},
+                                "warnings": {"type": "array",
+                                                     "items": msg_payload_item}
+                            }
+                        }
+                    }
                 }
               }
             }
@@ -372,6 +395,22 @@ def __pkg_info_output_schema():
                     "items": {"type": ["null", "string"]}}]}}}
             }
         }
+        return data_schema
+
+def __pkg_verify_output_schema():
+        data_schema = {"type": "object",
+            "properties": {
+                "plan": __get_plan_props(),
+                }
+            }
+        return data_schema
+
+def __pkg_fix_output_schema():
+        data_schema = {"type": "object",
+            "properties": {
+                "plan": __get_plan_props(),
+                }
+            }
         return data_schema
 
 def _format_update_error(e, errors_json=None):
@@ -804,135 +843,6 @@ def _accept_plan_licenses(api_inst):
 display_plan_options = ["basic", "fmris", "variants/facets", "services",
     "actions", "boot-archive"]
 
-def __get_parsable_plan(api_inst, parsable_version, child_images=None):
-        """Display the parsable version of the plan."""
-
-        assert parsable_version == 0, "parsable_version was {0!r}".format(
-            parsable_version)
-        plan = api_inst.describe()
-        # Set the default values.
-        added_fmris = []
-        removed_fmris = []
-        changed_fmris = []
-        affected_fmris = []
-        backup_be_created = False
-        new_be_created = False
-        backup_be_name = None
-        be_name = None
-        boot_archive_rebuilt = False
-        be_activated = True
-        space_available = None
-        space_required = None
-        facets_changed = []
-        variants_changed = []
-        services_affected = []
-        mediators_changed = []
-        editables_changed = []
-        licenses = []
-        if child_images is None:
-                child_images = []
-        release_notes = []
-
-        if plan:
-                for rem, add in plan.get_changes():
-                        assert rem is not None or add is not None
-                        if rem is not None and add is not None:
-                                # Lists of lists are used here becuase json will
-                                # convert lists of tuples into lists of lists
-                                # anyway.
-                                if rem.fmri == add.fmri:
-                                        affected_fmris.append(str(rem))
-                                else:
-                                        changed_fmris.append(
-                                            [str(rem), str(add)])
-                        elif rem is not None:
-                                removed_fmris.append(str(rem))
-                        else:
-                                added_fmris.append(str(add))
-                variants_changed, facets_changed = plan.varcets
-                backup_be_created = plan.backup_be
-                new_be_created = plan.new_be
-                backup_be_name = plan.backup_be_name
-                be_name = plan.be_name
-                boot_archive_rebuilt = plan.update_boot_archive
-                be_activated = plan.activate_be
-                space_available = plan.bytes_avail
-                space_required = plan.bytes_added
-                services_affected = plan.services
-                mediators_changed = plan.mediators
-
-                emoved, eremoved, einstalled, eupdated = \
-                    plan.get_editable_changes()
-
-                # Lists of lists are used here to ensure a consistent ordering
-                # and because tuples will be convereted to lists anyway; a
-                # dictionary would be more logical for the top level entries,
-                # but would make testing more difficult and this is a small,
-                # known set anyway.
-                emoved = [[e for e in entry] for entry in emoved]
-                eremoved = [src for (src, dest) in eremoved]
-                einstalled = [dest for (src, dest) in einstalled]
-                eupdated = [dest for (src, dest) in eupdated]
-                if emoved:
-                        editables_changed.append(["moved", emoved])
-                if eremoved:
-                        editables_changed.append(["removed", eremoved])
-                if einstalled:
-                        editables_changed.append(["installed", einstalled])
-                if eupdated:
-                        editables_changed.append(["updated", eupdated])
-
-                for n in plan.get_release_notes():
-                        release_notes.append(n)
-
-                for dfmri, src_li, dest_li, acc, disp in \
-                    plan.get_licenses():
-                        src_tup = None
-                        if src_li:
-                                li_txt = misc.decode(src_li.get_text())
-                                src_tup = (str(src_li.fmri), src_li.license,
-                                    li_txt, src_li.must_accept,
-                                    src_li.must_display)
-                        dest_tup = None
-                        if dest_li:
-                                li_txt = misc.decode(dest_li.get_text())
-                                dest_tup = (str(dest_li.fmri),
-                                    dest_li.license, li_txt,
-                                    dest_li.must_accept, dest_li.must_display)
-                        licenses.append(
-                            (str(dfmri), src_tup, dest_tup))
-                        api_inst.set_plan_license_status(dfmri, dest_li.license,
-                            displayed=True)
-
-        # The image name for the parent image is always None.  If this image is
-        # a child image, then the image name will be set when the parent image
-        # processes this dictionary.
-        ret = {
-            "activate-be": be_activated,
-            "add-packages": sorted(added_fmris),
-            "affect-packages": sorted(affected_fmris),
-            "affect-services": sorted(services_affected),
-            "backup-be-name": backup_be_name,
-            "be-name": be_name,
-            "boot-archive-rebuild": boot_archive_rebuilt,
-            "change-facets": sorted(facets_changed),
-            "change-editables": editables_changed,
-            "change-mediators": sorted(mediators_changed),
-            "change-packages": sorted(changed_fmris),
-            "change-variants": sorted(variants_changed),
-            "child-images": child_images,
-            "create-backup-be": backup_be_created,
-            "create-new-be": new_be_created,
-            "image-name": None,
-            "licenses": sorted(licenses, key=lambda x: x[0]),
-            "release-notes": release_notes,
-            "remove-packages": sorted(removed_fmris),
-            "space-available": space_available,
-            "space-required": space_required,
-            "version": parsable_version,
-        }
-        return ret
-
 def __api_alloc(pkg_image, orig_cwd, prog_delay=PROG_DELAY, prog_tracker=None,
     errors_json=None):
         """Allocate API instance."""
@@ -1239,13 +1149,19 @@ def __api_plan(_op, _api_inst, _accept=False, _li_ignore=None, _noexecute=False,
     _omit_headers=False, _origins=None, _parsable_version=None, _quiet=False,
     _quiet_plan=False, _review_release_notes=False, _show_licenses=False,
     _stage=API_STAGE_DEFAULT, _verbose=0, display_plan_cb=None, logger=None,
-    **kwargs):
+    _unpackaged=False, _unpackaged_only=False, **kwargs):
 
         # All the api interface functions that we invoke have some
         # common arguments.  Set those up now.
-        if _op not in (PKG_OP_REVERT, PKG_OP_FIX, PKG_OP_DEHYDRATE,
-            PKG_OP_REHYDRATE):
+        if _op not in (PKG_OP_REVERT, PKG_OP_FIX, PKG_OP_VERIFY,
+            PKG_OP_DEHYDRATE, PKG_OP_REHYDRATE):
                 kwargs["li_ignore"] = _li_ignore
+        if _op == PKG_OP_VERIFY:
+                kwargs["unpackaged"] = _unpackaged
+                kwargs["unpackaged_only"] = _unpackaged_only
+        elif _op == PKG_OP_FIX:
+                kwargs["unpackaged"] = _unpackaged
+
         kwargs["noexecute"] = _noexecute
         if _origins:
                 kwargs["repos"] = _origins
@@ -1283,6 +1199,8 @@ def __api_plan(_op, _api_inst, _accept=False, _li_ignore=None, _noexecute=False,
                 api_plan_func = _api_inst.gen_plan_uninstall
         elif _op == PKG_OP_UPDATE:
                 api_plan_func = _api_inst.gen_plan_update
+        elif _op == PKG_OP_VERIFY:
+                api_plan_func = _api_inst.gen_plan_verify
         else:
                 raise RuntimeError("__api_plan() invalid op: {0}".format(_op))
 
@@ -1308,8 +1226,8 @@ def __api_plan(_op, _api_inst, _accept=False, _li_ignore=None, _noexecute=False,
                                 display_plan_cb(_api_inst, [], _noexecute,
                                     _omit_headers, _op, _parsable_version,
                                     _quiet, _quiet_plan, _show_licenses,
-                                    _stage, _verbose,
-                                    get_parsable_plan_cb=__get_parsable_plan)
+                                    _stage, _verbose, _unpackaged,
+                                    _unpackaged_only)
 
                         # if requested accept licenses for child images.  we
                         # have to do this before recursing into children.
@@ -1342,10 +1260,12 @@ def __api_plan(_op, _api_inst, _accept=False, _li_ignore=None, _noexecute=False,
                                     _noexecute, _omit_headers, _op,
                                     _parsable_version, _quiet, _quiet_plan,
                                     _show_licenses, _stage, _verbose,
-                                    get_parsable_plan_cb=__get_parsable_plan)
+                                    _unpackaged, _unpackaged_only)
                         else:
-                                parsable_plan = __get_parsable_plan(_api_inst,
-                                    _parsable_version, child_plans)
+                                plan = _api_inst.describe()
+                                parsable_plan =plan.get_parsable_plan(
+                                    _parsable_version, child_plans,
+                                    api_inst=_api_inst)
                                 # Convert to json.
                                 parsable_plan = json.loads(json.dumps(
                                     parsable_plan))
@@ -1357,10 +1277,11 @@ def __api_plan(_op, _api_inst, _accept=False, _li_ignore=None, _noexecute=False,
         if not planned_self and _accept:
                 _accept_plan_licenses(_api_inst)
 
+        data = {}
         if parsable_plan:
-                data = {"plan": parsable_plan}
-                return __prepare_json(EXIT_OK, data=data)
-        return __prepare_json(EXIT_OK)
+                data["plan"] = parsable_plan
+
+        return __prepare_json(EXIT_OK, data=data)
 
 def __api_plan_file(api_inst):
         """Return the path to the PlanDescription save file."""
@@ -1425,20 +1346,22 @@ def __api_plan_delete(api_inst):
         except OSError as e:
                 raise api_errors._convert_error(e)
 
-def _verify_exit_code(api_inst):
-        """Determine the exit code of pkg verify, which should be based on
-        whether we find errors."""
+def __verify_exit_status(api_inst):
+        """Determine verify exit status."""
 
         plan = api_inst.describe()
-        for item_id, msg_time, msg_type, msg_text in plan.gen_item_messages():
-                if msg_type == MSG_ERROR:
+        for item_id, parent_id, msg_time, msg_level, msg_type, msg_text in \
+            plan.gen_item_messages():
+                if msg_level == MSG_ERROR:
                         return EXIT_OOPS
         return EXIT_OK
 
 def __api_op(_op, _api_inst, _accept=False, _li_ignore=None, _noexecute=False,
-    _origins=None, _parsable_version=None, _quiet=False,
+    _origins=None, _parsable_version=None, _quiet=False, _quiet_plan=False,
     _review_release_notes=False, _show_licenses=False,
-    _stage=API_STAGE_DEFAULT, _verbose=0, display_plan_cb=None, logger=None,
+    _stage=API_STAGE_DEFAULT, _verbose=0,
+    _unpackaged=False, _unpackaged_only=False,
+    display_plan_cb=None, logger=None,
     **kwargs):
         """Do something that involves the api.
 
@@ -1456,8 +1379,9 @@ def __api_op(_op, _api_inst, _accept=False, _li_ignore=None, _noexecute=False,
                     _parsable_version=_parsable_version, _quiet=_quiet,
                     _review_release_notes=_review_release_notes,
                     _show_licenses=_show_licenses, _stage=_stage,
-                    _verbose=_verbose, display_plan_cb=display_plan_cb,
-                    logger=logger, **kwargs)
+                    _verbose=_verbose, _quiet_plan=_quiet_plan,
+                    _unpackaged=_unpackaged, _unpackaged_only=_unpackaged_only,
+                    display_plan_cb=display_plan_cb, logger=logger, **kwargs)
 
                 if ret["status"] != EXIT_OK:
                         return ret
@@ -1472,9 +1396,11 @@ def __api_op(_op, _api_inst, _accept=False, _li_ignore=None, _noexecute=False,
                         # consumer from creating a noop plan and then
                         # preparing and executing it.)
                         __api_plan_save(_api_inst, logger=logger)
-                # for pkg verify
-                if _op == PKG_OP_FIX and _noexecute and _quiet_plan:
-                        return __prepare_json(_verify_exit_code(_api_inst))
+                # for pkg verify or fix.
+                if _op in [PKG_OP_FIX, PKG_OP_VERIFY] and _noexecute and \
+                    _quiet_plan:
+                        exit_code = __verify_exit_status(_api_inst)
+                        return __prepare_json(exit_code, data=data)
                 if _api_inst.planned_nothingtodo():
                         return __prepare_json(EXIT_NOP)
                 if _noexecute or _stage == API_STAGE_PLAN:
@@ -2516,6 +2442,36 @@ examining the catalogs:\n""")
 
         return __prepare_json(err, errors=errors_json, data=data)
 
+def _verify(op, api_inst, pargs, omit_headers, parsable_version, quiet, verbose,
+    unpackaged, unpackaged_only, display_plan_cb=None, logger=None):
+        """Determine if installed packages match manifests."""
+
+        errors_json = []
+        if pargs and unpackaged_only:
+                error = {"reason": _("can not report only unpackaged contents "
+                    "with package arguments.")}
+                errors_json.append(error)
+                return __prepare_json(EXIT_BADOPT, errors=errors_json)
+
+        return __api_op(op, api_inst, args=pargs, _noexecute=True,
+            _omit_headers=omit_headers, _quiet=quiet, _quiet_plan=True,
+            _verbose=verbose, _parsable_version=parsable_version,
+            _unpackaged=unpackaged, _unpackaged_only=unpackaged_only,
+            display_plan_cb=display_plan_cb, logger=logger)
+
+def _fix(op, api_inst, pargs, accept, backup_be, backup_be_name, be_activate,
+    be_name, new_be, noexecute, omit_headers, parsable_version, quiet,
+    show_licenses, verbose, unpackaged, display_plan_cb=None, logger=None):
+        """Fix packaging errors found in the image."""
+
+        return __api_op(op, api_inst, args=pargs, _accept=accept,
+            _noexecute=noexecute, _omit_headers=omit_headers, _quiet=quiet,
+            _show_licenses=show_licenses, _verbose=verbose, backup_be=backup_be,
+            backup_be_name=backup_be_name, be_activate=be_activate,
+            be_name=be_name, new_be=new_be, _parsable_version=parsable_version,
+            _unpackaged=unpackaged, display_plan_cb=display_plan_cb,
+            logger=logger)
+
 def __refresh(api_inst, pubs, full_refresh=False):
         """Private helper method for refreshing publisher data."""
 
@@ -2868,7 +2824,7 @@ def __pkg(subcommand, pargs_json, opts_json, pkg_image=None,
                 jsonschema.validate({arg_name: pargs, "opts_json": opts},
                     input_schema)
         except jsonschema.ValidationError as e:
-                return None, __prepare_json(EXIT_OOPS,
+                return None, __prepare_json(EXIT_BADOPT,
                     errors=[{"reason": str(e)}])
 
         orig_cwd = _get_orig_cwd()
@@ -3269,6 +3225,18 @@ class ClientInterface(object):
                 return self._cmd_invoke("publisher", pargs_json=pargs_json,
                     opts_json=opts_json)
 
+        def verify(self, pargs_json=None, opts_json=None):
+                """Invoke pkg verify subcommand."""
+
+                return self._cmd_invoke("verify", pargs_json=pargs_json,
+                    opts_json=opts_json)
+
+        def fix(self, pargs_json=None, opts_json=None):
+                """Invoke pkg fix subcommand."""
+
+                return self._cmd_invoke("fix", pargs_json=pargs_json,
+                    opts_json=opts_json)
+
         def get_pkg_input_schema(self, subcommand):
                 """Get input schema for a specific subcommand."""
 
@@ -3283,6 +3251,7 @@ class ClientInterface(object):
 
 cmds = {
     "exact-install"   : [_exact_install, __pkg_exact_install_output_schema],
+    "fix"             : [_fix, __pkg_fix_output_schema],
     "list"            : [_list_inventory, __pkg_list_output_schema],
     "install"         : [_install, __pkg_install_output_schema],
     "update"          : [_update, __pkg_update_output_schema],
@@ -3292,7 +3261,8 @@ cmds = {
     "unset-publisher" : [_publisher_unset,
                           __pkg_publisher_unset_output_schema],
     "publisher"       : [_publisher_list, __pkg_publisher_output_schema],
-    "info"            : [_info, __pkg_info_output_schema]
+    "info"            : [_info, __pkg_info_output_schema],
+    "verify"          : [_verify, __pkg_verify_output_schema]
 }
 
 # Addendum table for option extensions.

--- a/src/modules/client/client_api.py
+++ b/src/modules/client/client_api.py
@@ -1425,6 +1425,16 @@ def __api_plan_delete(api_inst):
         except OSError as e:
                 raise api_errors._convert_error(e)
 
+def _verify_exit_code(api_inst):
+        """Determine the exit code of pkg verify, which should be based on
+        whether we find errors."""
+
+        plan = api_inst.describe()
+        for item_id, msg_time, msg_type, msg_text in plan.gen_item_messages():
+                if msg_type == MSG_ERROR:
+                        return EXIT_OOPS
+        return EXIT_OK
+
 def __api_op(_op, _api_inst, _accept=False, _li_ignore=None, _noexecute=False,
     _origins=None, _parsable_version=None, _quiet=False,
     _review_release_notes=False, _show_licenses=False,
@@ -1462,6 +1472,9 @@ def __api_op(_op, _api_inst, _accept=False, _li_ignore=None, _noexecute=False,
                         # consumer from creating a noop plan and then
                         # preparing and executing it.)
                         __api_plan_save(_api_inst, logger=logger)
+                # for pkg verify
+                if _op == PKG_OP_FIX and _noexecute and _quiet_plan:
+                        return __prepare_json(_verify_exit_code(_api_inst))
                 if _api_inst.planned_nothingtodo():
                         return __prepare_json(EXIT_NOP)
                 if _noexecute or _stage == API_STAGE_PLAN:

--- a/src/modules/client/image.py
+++ b/src/modules/client/image.py
@@ -4316,7 +4316,8 @@ in the environment or by setting simulate_cmdpath in DebugValues.""")
                                         ip.plan_install(**kwargs)
                                 elif _op ==pkgdefs.API_OP_EXACT_INSTALL:
                                         ip.plan_exact_install(**kwargs)
-                                elif _op == pkgdefs.API_OP_FIX:
+                                elif _op in [pkgdefs.API_OP_FIX,
+                                    pkgdefs.API_OP_VERIFY]:
                                         ip.plan_fix(**kwargs)
                                 elif _op == pkgdefs.API_OP_REHYDRATE:
                                         ip.plan_rehydrate(**kwargs)
@@ -4520,12 +4521,15 @@ in the environment or by setting simulate_cmdpath in DebugValues.""")
                     noexecute, publishers=publishers)
                 progtrack.plan_all_done()
 
-        def make_fix_plan(self, op, progtrack, check_cancel, noexecute, args):
-                """Create an image plan to fix the image."""
+        def make_fix_plan(self, op, progtrack, check_cancel, noexecute, args,
+            unpackaged=False, unpackaged_only=False):
+                """Create an image plan to fix the image. Note: verify shares
+                the same routine."""
 
                 progtrack.plan_all_start()
                 self.__make_plan_common(op, progtrack, check_cancel, noexecute,
-                    args=args)
+                    args=args, unpackaged=unpackaged,
+                    unpackaged_only=unpackaged_only)
                 progtrack.plan_all_done()
 
         def make_noop_plan(self, op, progtrack, check_cancel,

--- a/src/modules/client/imageplan.py
+++ b/src/modules/client/imageplan.py
@@ -35,6 +35,7 @@ import itertools
 import mmap
 import operator
 import os
+import shutil
 import six
 import stat
 import sys
@@ -53,6 +54,7 @@ import pkg.actions
 import pkg.actions.driver as driver
 import pkg.catalog
 import pkg.client.api_errors as api_errors
+import pkg.client.bootenv as bootenv
 import pkg.client.indexer as indexer
 import pkg.client.linkedimage.zone as zone
 import pkg.client.pkg_solver as pkg_solver
@@ -72,7 +74,7 @@ from pkg.client.debugvalues import DebugValues
 from pkg.client.plandesc import _ActionPlan
 from pkg.mediator import mediator_impl_matches
 from pkg.client.pkgdefs import (PKG_OP_DEHYDRATE, PKG_OP_REHYDRATE, MSG_ERROR,
-    MSG_WARNING, MSG_INFO)
+    MSG_WARNING, MSG_INFO, MSG_GENERAL, MSG_UNPACKAGED, PKG_OP_VERIFY)
 
 class ImagePlan(object):
         """ImagePlan object contains the plan for changing the image...
@@ -1622,11 +1624,156 @@ class ImagePlan(object):
                 # We found errors and this is a file that can be overlaid.
                 overlaying = self.__get_overlaying_fmri(img, act, pfmri)
                 if overlaying:
-                        errors.append(_("verify or fix overlaying package: "
+                        errors.add(_("verify or fix overlaying package: "
                             "{0}").format(overlaying))
                 return True
 
-        def plan_fix(self, args):
+        def __is_active_liveroot_be(self, img):
+                """Check if an image is in an active live be."""
+
+                if not img.is_liveroot():
+                        return False, None
+
+                try:
+                        be_name, be_uuid = bootenv.BootEnv.get_be_name(
+                            img.root)
+                        return True, be_name
+                except api_errors.BEException:
+                        # If boot environment logic isn't supported, return
+                        # False.  This is necessary for user images and for
+                        # the test suite.
+                        return False, None
+
+        def __alt_image_root_with_new_be(self, dup_be_name, orig_img_root):
+                img_root = orig_img_root
+                mntpoint = None
+                isalbe, src_be_name = self.__is_active_liveroot_be(self.image)
+                if isalbe:
+                        try:
+                                bootenv.BootEnv.cleanup_be(dup_be_name)
+                                temp_root = misc.config_temp_root()
+                                mntpoint = tempfile.mkdtemp(dir=temp_root,
+                                    prefix="pkg-verify" + "-")
+                                bootenv.BootEnv.copy_be(src_be_name,
+                                    dup_be_name)
+                                bootenv.BootEnv.mount_be(dup_be_name, mntpoint)
+                                img_root = mntpoint
+                        except Exception as e:
+                                did_create = False
+                                be_list = bootenv.BootEnv.get_be_list()
+                                for elem in be_list:
+                                        if "orig_be_name" in elem and \
+                                            dup_be_name == \
+                                            elem["orig_be_name"]:
+                                                did_create = True
+                                                break
+                                warn = _("Cannot create or mount a copy of " \
+                                    "current be. Reporting unpackaged " \
+                                    "content aganist current live image.")
+                                timestamp = misc.time_to_timestamp(time.time())
+                                if did_create:
+                                        try:
+                                                if img_root != mntpoint:
+                                                        bootenv.BootEnv.mount_be(
+                                                            dup_be_name,
+                                                            mntpoint)
+                                                        img_root = mntpoint
+                                        except Exception as e:
+                                                # If we could not mount be,
+                                                # fallback.
+                                                self.pd.add_item_message(
+                                                    "warnings", timestamp,
+                                                    MSG_WARNING, warn,
+                                                    msg_type=MSG_UNPACKAGED,
+                                                    parent="unpackaged")
+                                else:
+                                        # If we could not create be,
+                                        # fallback.
+                                        self.pd.add_item_message(
+                                            "warnings", timestamp, MSG_WARNING,
+                                            warn, msg_type=MSG_UNPACKAGED,
+                                            parent="unpackaged")
+                return img_root, mntpoint
+
+        def __process_unpackaged(self, proposed_fmris, pt=None):
+                allentries = {}
+                img_root = self.image.get_root()
+
+                for fmri in proposed_fmris:
+                        m = self.image.get_manifest(fmri)
+                        for act in m.gen_actions():
+                                if act.name in ["link", "hardlink", "dir",
+                                    "file"]:
+                                        install_path = os.path.normpath(
+                                            os.path.join(img_root,
+                                            act.attrs["path"]))
+                                        allentries[install_path] = act.name
+                        # Process possible implicit directories.
+                        for d in m.get_directories(()):
+                                install_path = os.path.normpath(
+                                    os.path.join(img_root, d))
+                                if install_path not in allentries:
+                                        allentries[install_path] = "dir"
+                        if pt:
+                                pt.plan_add_progress(pt.PLAN_PKG_VERIFY)
+
+                def handle_walk_error(oserror_inst):
+                        timestamp = misc.time_to_timestamp(time.time())
+                        self.pd.add_item_message("errors", timestamp,
+                            MSG_ERROR, str(oserror_inst),
+                            msg_type=MSG_UNPACKAGED, parent="unpackaged")
+
+                orig_img_root = img_root
+                dup_be_name = "duplicate_livebe_for_verify"
+                img_root, mntpoint = self.__alt_image_root_with_new_be(
+                    dup_be_name, orig_img_root)
+
+                # Walk through file system structure.
+                for root, dirs, files in os.walk(img_root,
+                    onerror=handle_walk_error):
+                        newdirs = []
+                        # Since we possibly changed the img_root into the
+                        # mounted be root, we need to change it back for look
+                        # up.
+                        orig_root = os.path.normpath(os.path.join(
+                            orig_img_root, os.path.relpath(root, img_root)))
+                        for d in sorted(dirs):
+                                timestamp = misc.time_to_timestamp(time.time())
+                                path = os.path.normpath(os.path.join(
+                                    orig_root, d))
+                                # Since the mntpoint is created solely for
+                                # verify purpose, ignore it.
+                                if mntpoint and path == mntpoint:
+                                        continue
+                                if path not in allentries or allentries[path] \
+                                    not in ["dir", "link"]:
+                                        self.pd.add_item_message(
+                                            _("dir: {0}").format(path),
+                                            timestamp,
+                                            MSG_INFO,
+                                            _("Unpackaged directory"),
+                                            msg_type=MSG_UNPACKAGED,
+                                            parent="unpackaged")
+                                else:
+                                        newdirs.append(d)
+                        dirs[:] = newdirs
+
+                        for f in sorted(files):
+                                timestamp = misc.time_to_timestamp(time.time())
+                                path = os.path.normpath(os.path.join(
+                                    orig_root, f))
+                                if path not in allentries or allentries[path] \
+                                    not in ["file", "link", "hardlink"]:
+                                        self.pd.add_item_message(
+                                            _("file: {0}").format(path),
+                                            timestamp, MSG_INFO,
+                                            _("Unpackaged file"),
+                                            msg_type=MSG_UNPACKAGED,
+                                            parent="unpackaged")
+                # Clean up the BE used for verify.
+                bootenv.BootEnv.cleanup_be(dup_be_name)
+
+        def plan_fix(self, args, unpackaged=False, unpackaged_only=False):
                 """Determine the changes needed to fix the image."""
 
                 self.__plan_op()
@@ -1653,16 +1800,28 @@ class ImagePlan(object):
 
                 if proposed_fixes:
                         pt.plan_start(pt.PLAN_PKG_VERIFY, goal=len(proposed_fixes))
+                        # Verify unpackaged contents.
+                        if unpackaged or unpackaged_only:
+                                self.__process_unpackaged(proposed_fixes,
+                                    pt=pt)
+                                pt.plan_done(pt.PLAN_PKG_VERIFY)
+                                if unpackaged_only:
+                                        self.__finish_plan(plandesc.EVALUATED_PKGS)
+                                        return
+                                # Otherwise we reset the goals for packaged
+                                # contents.
+                                pt.plan_start(pt.PLAN_PKG_VERIFY, goal=len(
+                                    proposed_fixes))
+
                 repairs = []
 
                 for pfmri in proposed_fixes:
                         entries = []
                         needs_fix = []
-                        result = _("OK")
+                        result = "OK"
                         failed = False
-                        msg_type = MSG_INFO
+                        msg_level = MSG_INFO
                         ffmri = str(pfmri)
-                        timestamp = time.time()
 
                         # Since every entry returned by verify might not be
                         # something needing repair, the relevant information
@@ -1670,15 +1829,15 @@ class ImagePlan(object):
                         # an overall success/failure result and then the
                         # related messages output for it.
                         process_overlay = False
-                        errs = []
+                        errs = set()
                         for act, errors, warnings, pinfo in self.image.verify(
                             pfmri, pt, verbose=True, forever=True):
                                 # determine the package's status and message
                                 # type
                                 if errors:
                                         failed = True
-                                        result = _("ERROR")
-                                        msg_type = MSG_ERROR
+                                        result = "ERROR"
+                                        msg_level = MSG_ERROR
                                         # Some errors are based on policy (e.g.
                                         # signature policy) and not a specific
                                         # action, so act may be None.
@@ -1689,46 +1848,42 @@ class ImagePlan(object):
                                                     args, self.image, act, errs,
                                                     pfmri)
                                 elif not failed and warnings:
-                                        result = _("WARNING")
-                                        msg_type = MSG_WARNING
+                                        result = "WARNING"
+                                        msg_level = MSG_WARNING
 
                                 entries.append((act, errors, warnings, pinfo))
-
+                        timestamp = misc.time_to_timestamp(time.time())
                         self.pd.add_item_message(ffmri, timestamp,
-                            msg_type, _("{pkg_name:70} {result:>7}").format(
+                            msg_level, _("{pkg_name:70} {result:>7}").format(
                             pkg_name=pfmri.get_pkg_stem(),
                             result=result))
-                        if errs:
-                                self.pd.add_item_message(ffmri, timestamp,
-                                    msg_type, "\tERROR: {0}".format(errs[0]))
+                        timestamp = misc.time_to_timestamp(time.time())
+                        for e in errs:
+                                self.pd.add_item_message("overlay_errors",
+                                    timestamp, msg_level, e, parent=ffmri)
 
                         for act, errors, warnings, info in entries:
                                 if act:
-                                        # determine the action's message type
-                                        if errors:
-                                                msg_type = MSG_ERROR
-                                        elif warnings:
-                                                msg_type = MSG_WARNING
-                                        else:
-                                                msg_type = MSG_INFO
-
-                                        self.pd.add_item_message(ffmri,
-                                            timestamp, msg_type,
-                                            "\t{0}".format(
-                                            act.distinguished_name()))
-
+                                        item_id = act.distinguished_name()
+                                        parent = ffmri
+                                else:
+                                        item_id = ffmri
+                                        parent = None
                                 for x in errors:
-                                        self.pd.add_item_message(ffmri,
+                                        self.pd.add_item_message(item_id,
                                             timestamp, MSG_ERROR,
-                                            "\t\tERROR: {0}".format(x))
+                                            _("ERROR: {0}").format(x),
+                                            parent=parent)
                                 for x in warnings:
-                                        self.pd.add_item_message(ffmri,
+                                        self.pd.add_item_message(item_id,
                                             timestamp, MSG_WARNING,
-                                            "\t\tWARNING: {0}".format(x))
+                                            _("WARNING: {0}").format(x),
+                                            parent=parent)
                                 for x in info:
-                                        self.pd.add_item_message(ffmri,
+                                        self.pd.add_item_message(item_id,
                                             timestamp, MSG_INFO,
-                                            "\t\t{0}".format(x))
+                                            _("{0}").format(x),
+                                            parent=parent)
 
                         if not needs_fix:
                                 continue
@@ -1739,12 +1894,12 @@ class ImagePlan(object):
                 if proposed_fixes:
                         pt.plan_done(pt.PLAN_PKG_VERIFY)
 
-                # Repair anything we failed to verify
+                # If no repairs, finish the plan.
                 if not repairs:
-                        # No repairs for this image.
                         self.__finish_plan(plandesc.EVALUATED_PKGS)
                         return
 
+                # Repair anything we failed to verify.
                 pt.plan_start(pt.PLAN_PKG_FIX, goal=len(repairs))
                 for fmri, actions in repairs:
                         pt.plan_add_progress(pt.PLAN_PKG_FIX)
@@ -5297,7 +5452,9 @@ class ImagePlan(object):
 
                         except (pkg.fmri.FmriError,
                             pkg.version.VersionError) as e:
-                                illegals.append(e)
+                                # illegals should be a list of fmri patterns so that
+                                # PackageMatchErrors can construct correct error message.
+                                illegals.append(pat)
                 patterns = npatterns
                 del npatterns, seen
 

--- a/src/modules/client/imageplan.py
+++ b/src/modules/client/imageplan.py
@@ -1593,6 +1593,39 @@ class ImagePlan(object):
                             mode=mode, owner="root",
                             group="bin", path=pubpath)
 
+        def __get_overlaying_fmri(self, img, act, pfmri):
+                """Given an action with attribute overlay=allow, if there is an
+                overlaying action installed in the image, return the overlaying
+                package's name."""
+
+                for f in img.gen_installed_pkgs():
+                        if f == pfmri:
+                                # Not interested in ourselves.
+                                continue
+                        m = img.get_manifest(f)
+                        matching = list(m.gen_actions_by_types([act.name],
+                            {"path": [act.attrs["path"]]}))
+                        if matching:
+                                # Only one action can overlay another, so we
+                                # know we've found a match at this point.
+                                return f.get_pkg_stem(anarchy=True)
+
+        def __process_verify_result(self, args, img, act, errors, pfmri):
+                """Look further to see if we can include more details in the
+                verify result."""
+
+                if not args or act.name != "file" or \
+                    not act.attrs.get("overlay") == "allow":
+                        # No further processing required.
+                        return False
+
+                # We found errors and this is a file that can be overlaid.
+                overlaying = self.__get_overlaying_fmri(img, act, pfmri)
+                if overlaying:
+                        errors.append(_("verify or fix overlaying package: "
+                            "{0}").format(overlaying))
+                return True
+
         def plan_fix(self, args):
                 """Determine the changes needed to fix the image."""
 
@@ -1636,6 +1669,8 @@ class ImagePlan(object):
                         # for each package must be accumulated first to find
                         # an overall success/failure result and then the
                         # related messages output for it.
+                        process_overlay = False
+                        errs = []
                         for act, errors, warnings, pinfo in self.image.verify(
                             pfmri, pt, verbose=True, forever=True):
                                 # determine the package's status and message
@@ -1648,6 +1683,11 @@ class ImagePlan(object):
                                         # signature policy) and not a specific
                                         # action, so act may be None.
                                         needs_fix.append(act)
+                                        if act and not process_overlay:
+                                                process_overlay = \
+                                                    self.__process_verify_result(
+                                                    args, self.image, act, errs,
+                                                    pfmri)
                                 elif not failed and warnings:
                                         result = _("WARNING")
                                         msg_type = MSG_WARNING
@@ -1658,34 +1698,37 @@ class ImagePlan(object):
                             msg_type, _("{pkg_name:70} {result:>7}").format(
                             pkg_name=pfmri.get_pkg_stem(),
                             result=result))
+                        if errs:
+                                self.pd.add_item_message(ffmri, timestamp,
+                                    msg_type, "\tERROR: {0}".format(errs[0]))
 
                         for act, errors, warnings, info in entries:
-                                    if act:
-                                            # determine the action's message type
-                                            if errors:
-                                                    msg_type = MSG_ERROR
-                                            elif warnings:
-                                                    msg_type = MSG_WARNING
-                                            else:
-                                                    msg_type = MSG_INFO
+                                if act:
+                                        # determine the action's message type
+                                        if errors:
+                                                msg_type = MSG_ERROR
+                                        elif warnings:
+                                                msg_type = MSG_WARNING
+                                        else:
+                                                msg_type = MSG_INFO
 
-                                            self.pd.add_item_message(ffmri,
-                                                timestamp, msg_type,
-                                                "\t{0}".format(
-                                                act.distinguished_name()))
+                                        self.pd.add_item_message(ffmri,
+                                            timestamp, msg_type,
+                                            "\t{0}".format(
+                                            act.distinguished_name()))
 
-                                    for x in errors:
-                                            self.pd.add_item_message(ffmri,
-                                                timestamp, MSG_ERROR,
-                                                "\t\tERROR: {0}".format(x))
-                                    for x in warnings:
-                                            self.pd.add_item_message(ffmri,
-                                                timestamp, MSG_WARNING,
-                                                "\t\tWARNING: {0}".format(x))
-                                    for x in info:
-                                            self.pd.add_item_message(ffmri,
-                                                timestamp, MSG_INFO,
-                                                "\t\t{0}".format(x))
+                                for x in errors:
+                                        self.pd.add_item_message(ffmri,
+                                            timestamp, MSG_ERROR,
+                                            "\t\tERROR: {0}".format(x))
+                                for x in warnings:
+                                        self.pd.add_item_message(ffmri,
+                                            timestamp, MSG_WARNING,
+                                            "\t\tWARNING: {0}".format(x))
+                                for x in info:
+                                        self.pd.add_item_message(ffmri,
+                                            timestamp, MSG_INFO,
+                                            "\t\t{0}".format(x))
 
                         if not needs_fix:
                                 continue

--- a/src/modules/client/pkgdefs.py
+++ b/src/modules/client/pkgdefs.py
@@ -116,6 +116,7 @@ API_OP_SET_MEDIATOR   = "set-mediator"
 API_OP_SYNC           = "sync-linked"
 API_OP_UNINSTALL      = "uninstall"
 API_OP_UPDATE         = "update"
+API_OP_VERIFY         = "verify"
 api_op_values         = frozenset([
     API_OP_ATTACH,
     API_OP_CHANGE_FACET,
@@ -131,7 +132,8 @@ api_op_values         = frozenset([
     API_OP_SET_MEDIATOR,
     API_OP_SYNC,
     API_OP_UNINSTALL,
-    API_OP_UPDATE
+    API_OP_UPDATE,
+    API_OP_VERIFY
 ])
 
 API_STAGE_DEFAULT  = "default"
@@ -192,10 +194,14 @@ PKG_STATE_FROZEN = 11
 # to disk.
 PKG_STATE_ALT_SOURCE = 99
 
+# Message levels
+MSG_ERROR = "error"
+MSG_WARNING = "warning"
+MSG_INFO = "info"
+
 # Message types
-MSG_ERROR = 0
-MSG_WARNING = 1
-MSG_INFO = 2
+MSG_GENERAL = "general"
+MSG_UNPACKAGED = "unpackaged"
 
 # Vim hints
 # vim:ts=8:sw=8:et:fdm=marker

--- a/src/tests/cli/t_client_api.py
+++ b/src/tests/cli/t_client_api.py
@@ -21,7 +21,7 @@
 #
 
 #
-# Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
 #
 
 from . import testutils
@@ -78,14 +78,46 @@ class TestClientApi(pkg5unittest.ManyDepotTestCase):
             open hier/foo@1.0,5.11-0
             close """
 
+        verifypkg10 = """
+            open verifypkg@1.0,5.11-0:20160302T054916Z
+            add dir mode=0755 owner=root group=sys path=/etc
+            add dir mode=0755 owner=root group=sys path=/etc/security
+            add dir mode=0755 owner=root group=sys path=/usr
+            add dir mode=0755 owner=root group=bin path=/usr/bin
+            add file bobcat mode=0644 owner=root group=bin path=/usr/bin/bobcat
+            add file bobcat path=/etc/preserved mode=644 owner=root group=sys preserve=true timestamp="20080731T024051Z"
+            add file dricon_maj path=/etc/name_to_major mode=644 owner=root group=sys preserve=true
+            add file dricon_da path=/etc/driver_aliases mode=644 owner=root group=sys preserve=true
+            add file dricon_cls path=/etc/driver_classes mode=644 owner=root group=sys preserve=true
+            add file dricon_mp path=/etc/minor_perm mode=644 owner=root group=sys preserve=true
+            add file dricon_dp path=/etc/security/device_policy mode=644 owner=root group=sys preserve=true
+            add file dricon_ep path=/etc/security/extra_privs mode=644 owner=root group=sys preserve=true
+            add file permission mode=0600 owner=root group=bin path=/etc/permission preserve=true
+            add driver name=zigit alias=pci8086,1234
+            close
+            """
+
+        misc_files = {
+           "bobcat": "",
+           "dricon_da": """zigit "pci8086,1234"\n""",
+           "dricon_maj": """zigit 103\n""",
+           "dricon_cls": """\n""",
+           "dricon_mp": """\n""",
+           "dricon_dp": """\n""",
+           "dricon_ep": """\n""",
+           "permission": ""
+        }
+
         def setUp(self):
                 pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test2",
                     "test2"])
+                self.make_misc_files(self.misc_files)
 
                 self.rurl1 = self.dcs[1].get_repo_url()
                 self.pkgsend_bulk(self.rurl1, (self.foo1, self.foo10,
                     self.foo11, self.foo12, self.foo121, self.food12,
-                    self.hierfoo10, self.newpkg10, self.newpkg210))
+                    self.hierfoo10, self.newpkg10, self.newpkg210,
+                    self.verifypkg10))
 
                 # Ensure that the second repo's packages have exactly the same
                 # timestamps as those in the first ... by copying the repo over.
@@ -179,7 +211,7 @@ class TestClientApi(pkg5unittest.ManyDepotTestCase):
                 try:
                         jsonschema.validate(input, schema)
                         return True
-                except:
+                except Exception as e:
                         return False
 
         def test_03_list_json_args_opts(self):
@@ -284,7 +316,7 @@ class TestClientApi(pkg5unittest.ManyDepotTestCase):
 
                 # Run through pkg install.
                 pkgs = ["newpkg@1.0"]
-                opts = {"verbose": 3, "parsable_version": 0}
+                opts = {"parsable_version": 0}
                 global_settings.client_output_quiet = True
                 retjson = self.__call_cmd("install", pkgs, opts)
                 global_settings.client_output_quiet = False
@@ -395,7 +427,7 @@ class TestClientApi(pkg5unittest.ManyDepotTestCase):
                 # Run through pkg update.
                 self.pkg("install pkg://test1/foo@1.0")
                 pkgs = ["foo@1.1"]
-                opts = {"verbose": 3, "parsable_version": 0}
+                opts = {"parsable_version": 0}
 
                 retjson = self.__call_cmd("update", pkgs, opts)
                 self.assertTrue("errors" not in retjson)
@@ -474,7 +506,7 @@ class TestClientApi(pkg5unittest.ManyDepotTestCase):
                 # Run through pkg uninstall.
                 self.pkg("install pkg://test1/foo@1.0")
                 pkgs = ["foo"]
-                opts = {"verbose": 3, "parsable_version": 0}
+                opts = {"parsable_version": 0}
 
                 retjson = self.__call_cmd("uninstall", pkgs, opts)
                 self.assertTrue("errors" not in retjson)
@@ -520,13 +552,13 @@ class TestClientApi(pkg5unittest.ManyDepotTestCase):
                 self.assertTrue("errors" not in retjson)
 
                 pkgs = ["newpkg@1.0"]
-                opts = {"verbose": 3, "parsable_version": 0}
+                opts = {"parsable_version": 0}
                 retjson = self.__call_cmd("install", pkgs, opts)
                 self.assertTrue("errors" not in retjson)
                 self.assertTrue(retjson["status"] == 0)
 
                 pkgs = ["newpkg"]
-                opts = {"verbose": 3, "parsable_version": 0}
+                opts = {"parsable_version": 0}
                 retjson = self.__call_cmd("uninstall", pkgs, opts)
                 self.assertTrue("errors" not in retjson)
                 self.assertTrue(retjson["status"] == 0)
@@ -555,7 +587,7 @@ class TestClientApi(pkg5unittest.ManyDepotTestCase):
                 self.assertTrue("errors" not in retjson)
 
                 pkgs = ["pkg://test1/foo@1"]
-                opts = {"verbose": 3, "parsable_version": 0}
+                opts = {"parsable_version": 0}
                 retjson = self.__call_cmd("install", pkgs, opts)
                 self.assertTrue("errors" not in retjson)
                 self.assertTrue(retjson["status"] == 0)
@@ -656,7 +688,7 @@ class TestClientApi(pkg5unittest.ManyDepotTestCase):
                 opts = {"output_format": ["invalid"]}
                 retjson = self.__call_cmd("publisher", pubs, opts)
                 self.assertTrue("errors" in retjson)
-                self.assertTrue(retjson["status"] == 1)
+                self.assertTrue(retjson["status"] == 2)
 
                 pubs = []
                 opts = {"output_format": None}
@@ -674,7 +706,7 @@ class TestClientApi(pkg5unittest.ManyDepotTestCase):
                 opts = {"inc_disabled": "False"}
                 retjson = self.__call_cmd("publisher", pubs, opts)
                 self.assertTrue("errors" in retjson)
-                self.assertTrue(retjson["status"] == 1)
+                self.assertTrue(retjson["status"] == 2)
 
                 pubs = ["test1"]
                 opts = {}
@@ -713,25 +745,25 @@ class TestClientApi(pkg5unittest.ManyDepotTestCase):
                 opts = {"origins": [None]}
                 retjson = self.__call_cmd("info", pkgs, opts)
                 self.assertTrue("errors" in retjson)
-                self.assertTrue(retjson["status"] == 1)
+                self.assertTrue(retjson["status"] == 2)
 
                 pkgs = []
                 opts = {"origins": None}
                 retjson = self.__call_cmd("info", pkgs, opts)
                 self.assertTrue("errors" in retjson)
-                self.assertTrue(retjson["status"] == 1)
+                self.assertTrue(retjson["status"] == 2)
 
                 opts = {"origins": "single"}
                 retjson = self.__call_cmd("info", pkgs, opts)
                 self.assertTrue("errors" in retjson)
-                self.assertTrue(retjson["status"] == 1)
+                self.assertTrue(retjson["status"] == 2)
 
                 pkgs = ["foo"]
                 opts = {"origins": [self.rurl1], "quiet": "True"}
                 retjson = self.__call_cmd("info", pkgs, opts)
                 self.assertTrue("errors" in retjson)
                 self.assertTrue("data" not in retjson)
-                self.assertTrue(retjson["status"] == 1)
+                self.assertTrue(retjson["status"] == 2)
 
                 pkgs = ["foo"]
                 opts = {"origins": [self.rurl1], "quiet": True}
@@ -776,7 +808,7 @@ class TestClientApi(pkg5unittest.ManyDepotTestCase):
                 retjson = self.__call_cmd("info", pkgs, opts)
                 self.assertTrue("errors" in retjson)
                 self.assertTrue("data" not in retjson)
-                self.assertTrue(retjson["status"] == 1)
+                self.assertTrue(retjson["status"] == 2)
 
         def test_10_exact_install_json_args_opts(self):
                 """Test json args or opts for exact-install command."""
@@ -815,7 +847,7 @@ class TestClientApi(pkg5unittest.ManyDepotTestCase):
 
                 # Run through pkg install.
                 pkgs = ["newpkg@1.0"]
-                opts = {"verbose": 3, "parsable_version": 0}
+                opts = {"parsable_version": 0}
                 global_settings.client_output_quiet = True
                 retjson = self.__call_cmd("exact-install", pkgs, opts)
                 global_settings.client_output_quiet = False
@@ -880,7 +912,189 @@ class TestClientApi(pkg5unittest.ManyDepotTestCase):
                 self.assertTrue(not self.__schema_validation(einstall_input,
                     einstall_schema))
 
-        def test_11_ClientInterface(self):
+        def test_11_verify_json_args_opts(self):
+                """Test json args or opts for verify command."""
+
+                self.image_create(self.rurl1, prefix="test1")
+                os.environ["PKG_IMAGE"] = self.img_path()
+                pkgs = ["verifypkg@1.0"]
+                opts = {"parsable_version": 0}
+                global_settings.client_output_quiet = True
+                retjson = self.__call_cmd("install", pkgs, opts)
+                global_settings.client_output_quiet = False
+
+                # Test invalid options.
+                pkgs = ["verifypkg"]
+                opts = {"omit_headers": True, "parsable_version": 0}
+                retjson = self.__call_cmd("verify", pkgs, opts)
+                self.assertTrue(retjson["status"] == 2)
+                self.assertTrue("combined" in retjson["errors"][0]["reason"])
+
+                pkgs = ["verifypkg"]
+                opts = {"fake_opt": True}
+                retjson = self.__call_cmd("verify", pkgs, opts)
+                self.assertTrue(retjson["status"] == 2)
+                self.assertTrue("invalid" in retjson["errors"][0]["reason"])
+
+                pkgs = ["verifypkg"]
+                opts = {"parsable_version": "wrongValueType"}
+                retjson = self.__call_cmd("verify", pkgs, opts)
+                self.assertTrue(retjson["status"] == 2)
+
+                pkgs = ["verifypkg"]
+                opts = {"parsable_version": 1}
+                retjson = self.__call_cmd("verify", pkgs, opts)
+                self.assertTrue(retjson["status"] == 2)
+
+                pkgs = ["verifypkg"]
+                opts = {"unpackaged_only": True}
+                retjson = self.__call_cmd("verify", pkgs, opts)
+                self.assertTrue(retjson["status"] == 2)
+
+                pkgs = ["verifypkg"]
+                opts = {"unpackaged": True}
+                retjson = self.__call_cmd("verify", pkgs, opts)
+                self.assertTrue(retjson["status"] == 0)
+
+                # Run through verify.
+                pkgs = ["verifypkg"]
+                opts = {"parsable_version": 0}
+                retjson = self.__call_cmd("verify", pkgs, opts)
+                self.assertTrue(retjson["status"] == 0)
+                self.assertTrue(retjson["data"]["plan"]["item-messages"])
+                reslist = retjson["data"]["plan"]["item-messages"]
+                self.assertTrue(len(reslist) == 1 and
+                    reslist['pkg://test1/verifypkg@1.0,5.11-0:20160302T054916Z']
+                    ["messages"][0]["msg_level"] == "info")
+                verify_outschema = cli_api._get_pkg_output_schema("verify")
+                self.assertTrue(self.__schema_validation(retjson,
+                    verify_outschema))
+
+                pkgs = []
+                opts = {"unpackaged": True, "parsable_version": 0}
+                retjson = self.__call_cmd("verify", pkgs, opts)
+
+                self.assertTrue(retjson["status"] == 0)
+                self.assertTrue(retjson["data"]["plan"]
+                    ["item-messages"])
+                reslist = retjson["data"]["plan"]["item-messages"]["unpackaged"]
+
+                # /var is unpackaged
+                self.assertTrue(len(reslist) == 1
+                    and list(reslist.values())[0][0]["msg_level"] == "info")
+                # Also check if the packaged content is still there.
+                reslist = retjson["data"]["plan"]["item-messages"]
+                self.assertTrue(len(reslist) == 2 and
+                    reslist['pkg://test1/verifypkg@1.0,5.11-0:20160302T054916Z']
+                    ["messages"][0]["msg_level"] == "info")
+                self.assertTrue(self.__schema_validation(retjson,
+                    verify_outschema))
+
+                pkgs = []
+                opts = {"unpackaged_only": True, "parsable_version": 0}
+                retjson = self.__call_cmd("verify", pkgs, opts)
+                self.assertTrue(retjson["status"] == 0)
+                self.assertTrue(retjson["data"]["plan"]
+                    ["item-messages"])
+                reslist = retjson["data"]["plan"]["item-messages"]["unpackaged"]
+
+                self.assertTrue(len(reslist) == 1
+                    and list(reslist.values())[0][0]["msg_level"] == "info")
+                # Also check if the packaged content is gone.
+                reslist = retjson["data"]["plan"]["item-messages"]
+                self.assertTrue(len(reslist) == 1 and
+                    'pkg://test1/verifypkg@1.0,5.11-0:20160302T054916Z'
+                    not in reslist)
+                self.assertTrue(self.__schema_validation(retjson,
+                    verify_outschema))
+
+                # Test input directly against schema.
+                pargs = "pargs_json"
+                verify_schema = cli_api._get_pkg_input_schema("verify")
+                verify_input = {pargs : [], "opts_json": {}}
+                self.assertTrue(self.__schema_validation(verify_input,
+                    verify_schema))
+
+                verify_input = {pargs : [], "opts_json": {"unpackaged":
+                    "wrongValueType"}}
+                self.assertTrue(not self.__schema_validation(verify_input,
+                    verify_schema))
+
+        def test_12_fix_json_args_opts(self):
+                """Test json args or opts for fix command."""
+
+                self.image_create(self.rurl1, prefix="test1")
+                os.environ["PKG_IMAGE"] = self.img_path()
+                pkgs = ["verifypkg@1.0"]
+                opts = {"parsable_version": 0}
+                global_settings.client_output_quiet = True
+                retjson = self.__call_cmd("install", pkgs, opts)
+                global_settings.client_output_quiet = False
+
+                # Test invalid options.
+                pkgs = ["verifypkg"]
+                opts = {"omit_headers": True, "parsable_version": 0}
+                retjson = self.__call_cmd("fix", pkgs, opts)
+                self.assertTrue(retjson["status"] == 2)
+                self.assertTrue("combined" in retjson["errors"][0]["reason"])
+
+                pkgs = ["verifypkg"]
+                opts = {"fake_opt": True}
+                retjson = self.__call_cmd("fix", pkgs, opts)
+                self.assertTrue(retjson["status"] == 2)
+                self.assertTrue("invalid" in retjson["errors"][0]["reason"])
+
+                pkgs = ["verifypkg"]
+                opts = {"parsable_version": "wrongValueType"}
+                retjson = self.__call_cmd("fix", pkgs, opts)
+                self.assertTrue(retjson["status"] == 2)
+
+                opts = {"unpackaged": True}
+                retjson = self.__call_cmd("fix", pkgs, opts)
+                self.assertTrue(retjson["status"] == 4)
+
+                pkgs = []
+                opts = {"unpackaged": True}
+                retjson = self.__call_cmd("fix", pkgs, opts)
+                self.assertTrue(retjson["status"] == 4)
+
+                pkgs = []
+                opts = {"unpackaged_only": True}
+                retjson = self.__call_cmd("fix", pkgs, opts)
+                self.assertTrue(retjson["status"] == 2)
+
+                # Run through fix.
+                pkgs = ["verifypkg"]
+                opts = {"parsable_version": 0}
+                retjson = self.__call_cmd("fix", pkgs, opts)
+                self.assertTrue(retjson["status"] == 4)
+
+                # Modify file
+                self.file_append("usr/bin/bobcat", "foobar")
+                retjson = self.__call_cmd("fix", pkgs, opts)
+
+                self.assertTrue(retjson["data"]["plan"]["item-messages"])
+                reslist = retjson["data"]["plan"]["item-messages"]
+                self.assertTrue(len(reslist) == 1 and
+                    reslist['pkg://test1/verifypkg@1.0,5.11-0:20160302T054916Z']
+                    ["messages"][0]["msg_level"] == "error")
+                fix_outschema = cli_api._get_pkg_output_schema("fix")
+                self.assertTrue(self.__schema_validation(retjson,
+                    fix_outschema))
+                # Test input directly against schema.
+                pargs = "pargs_json"
+                fix_schema = cli_api._get_pkg_input_schema("fix")
+                fix_input = {pargs : [], "opts_json": {}}
+                self.assertTrue(self.__schema_validation(fix_input,
+                    fix_schema))
+
+                pargs = "pargs_json"
+                fix_schema = cli_api._get_pkg_input_schema("fix")
+                fix_input = {pargs : [], "opts_json": {"verbose": "WrongType"}}
+                self.assertTrue(not self.__schema_validation(fix_input,
+                    fix_schema))
+
+        def test_13_ClientInterface(self):
                 """Test the clientInterface class."""
                 pt = progress.QuietProgressTracker()
                 cli_inst = cli_api.ClientInterface(pkg_image=self.img_path(),

--- a/src/tests/cli/t_fix.py
+++ b/src/tests/cli/t_fix.py
@@ -65,6 +65,17 @@ class TestFix(pkg5unittest.SingleDepotTestCase):
             add dir path=etc mode=0755 owner=root group=bin
             close """
 
+        pkg_dupfile = """
+            open dupfile@0,5.11-0
+            add file tmp/file1 path=dir/pathname mode=0755 owner=root group=bin preserve=renameold overlay=allow
+            close
+        """
+        pkg_duplink = """
+            open duplink@0,5.11-0
+            add link path=dir/pathname target=dir/other preserve=renameold overlay=true
+            close
+        """
+
         # All of these purposefully omit dir dependency.
         file10 = """
             open file@1.0,5.11-0
@@ -109,14 +120,38 @@ class TestFix(pkg5unittest.SingleDepotTestCase):
 
         sysattr = """
             open sysattr@1.0-0
-            add file amber1 mode=0555 owner=root group=bin sysattr=nodump preserve=true path=amber1 timestamp=20100731T014051Z
+            add file amber1 mode=0555 owner=root group=bin sysattr=nodump preserve=true path=amber1 timestamp=20100731T014051Z overlay=allow
             add file amber2 mode=0555 owner=root group=bin sysattr=nodump path=amber2 timestamp=20100731T014051Z
             close"""
 
-        misc_files = [ "copyright.licensed", "license.licensed", "libc.so.1",
-            "license.licensed", "license.licensed.addendum", "amber1", "amber2"]
+        sysattr_o = """
+            open sysattr_overlay@1.0-0
+            add file mode=0555 owner=root group=bin sysattr=nodump preserve=true path=amber1 overlay=true
+            close"""
 
-        misc_files2 = { "tmp/empty": "" }
+        gss = """
+            open gss@1.0-0
+            add file mech_1 path=etc/gss/mech owner=root group=sys mode=0644 overlay=allow preserve=renameold
+            add file mech_3 path=etc/gss/mech_1 owner=root group=sys mode=0644 overlay=allow preserve=renameold
+            close """
+
+        krb = """
+            open krb5@1.0-0
+            add file mech_2 path=etc/gss/mech owner=root group=sys mode=0644 overlay=true preserve=renameold
+            add file mech_4 path=etc/gss/mech_1 owner=root group=sys mode=0644 overlay=true preserve=renameold
+            close """
+
+        misc_files = [ "copyright.licensed", "license.licensed", "libc.so.1",
+            "license.licensed", "license.licensed.addendum", "amber1", "amber2",
+            "tmp/file1"]
+
+        misc_files2 = {
+            "tmp/empty": "",
+            "mech_1": """kerberos_v5 1.2.840.113554.1.2.2 mech_krb5.so kmech_krb5\n""",
+            "mech_2": """\n""",
+            "mech_3": """kerberos_v5 1.2.840.113554.1.2.2 mech_krb5.so kmech_krb5\n""",
+            "mech_4": """\n"""
+        }
 
         def setUp(self):
                 pkg5unittest.SingleDepotTestCase.setUp(self, start_depot=True)
@@ -126,11 +161,14 @@ class TestFix(pkg5unittest.SingleDepotTestCase):
                 for p in self.pkgsend_bulk(self.rurl, (self.amber10,
                     self.licensed13, self.dir10, self.file10, self.preserve10,
                     self.preserve11, self.preserve12, self.driver10,
-                    self.driver_prep10, self.sysattr)):
+                    self.driver_prep10, self.sysattr, self.sysattr_o, self.gss,
+                    self.krb, self.pkg_dupfile, self.pkg_duplink)):
                         pfmri = fmri.PkgFmri(p)
+                        old_publisher = pfmri.publisher
                         pfmri.publisher = None
                         sfmri = pfmri.get_short_fmri().replace("pkg:/", "")
                         self.plist[sfmri] = pfmri
+                        pfmri.publisher = old_publisher
 
         def test_01_basics(self):
                 """Basic fix test: install the amber package, modify one of the
@@ -491,6 +529,122 @@ class TestFix(pkg5unittest.SingleDepotTestCase):
                 self.__do_alter_verify(pfmri, quiet=True)
                 assert(self.output == "")
 
+        def test_fix_overlay(self):
+                """Test that pkg verify / fix should tell the users to look at
+                the overlaying package in the error message if fix won't repair
+                the overlaid package."""
+
+                file_path = "etc/gss/mech"
+                file_path_1 = "etc/gss/mech_1"
+                self.image_create(self.rurl)
+                pfmri_gss = self.plist["gss@1.0-0"]
+                pfmri_krb = self.plist["krb5@1.0-0"]
+                pfmri_sysattr = self.plist["sysattr@1.0-0"]
+                pfmri_sysattr_o = self.plist["sysattr_overlay@1.0-0"]
+
+                # First, only install the package that has a file with
+                # attribute overlay=allow.
+                self.pkg("install gss")
+                self.file_exists(file_path)
+                self.file_remove(file_path)
+                self.file_doesnt_exist(file_path)
+                # Verify should report an error if the file is missing.
+                self.pkg("verify -v gss", exit=1)
+                # Fix should be able to repair the file.
+                self.pkg("fix -v gss")
+                self.file_exists(file_path)
+                self.__do_alter_verify(pfmri_gss)
+
+                # Install the overlaying package.
+                self.pkg("install krb5")
+                self.file_exists(file_path)
+                self.file_remove(file_path)
+                self.file_doesnt_exist(file_path)
+
+                # Now pkg verify should still report an error on the overlaid
+                # package and tell the users to verify the overlaying package.
+                self.pkg("verify gss", exit=1)
+                self.assertTrue("package: {0}".format(
+                    pfmri_krb.get_pkg_stem(anarchy=True)) in self.output)
+                # Verify should report an error on the overlaying package.
+                self.pkg("verify krb5", exit=1)
+                # Fix won't repair the overlaid package but will tell the users
+                # to fix the overlaying package in the verbose mode.
+                self.pkg("fix gss", exit=4)
+                self.pkg("fix -v gss", exit=4)
+                self.assertTrue("Could not repair: {0}".format(pfmri_gss) in
+                    self.output)
+                self.assertTrue("package: {0}".format(
+                    pfmri_krb.get_pkg_stem(anarchy=True)) in self.output)
+                self.file_doesnt_exist(file_path)
+
+                # Fix should be able to repair the file by fixing the overlaying
+                # package.
+                self.pkg("fix -v pkg:/krb5")
+                self.pkg("verify gss")
+                self.file_exists(file_path)
+
+                # Test that multiple overlaid files are missing.
+                self.file_remove(file_path)
+                self.file_remove(file_path_1)
+                self.pkg("verify gss", exit=1)
+                # Test that the overlay warning only emits once for each
+                # package.
+                self.pkg("verify gss | grep 'verify or fix' | wc -l | grep 1")
+                self.pkg("fix krb5")
+
+                # Test the owner, group and mode change.
+                self.__do_alter_verify(pfmri_gss, verbose=True, exit=4)
+                self.assertTrue("Could not repair: {0}".format(pfmri_gss) in
+                    self.output)
+                self.assertTrue("package: {0}".format(
+                    pfmri_krb.get_pkg_stem(anarchy=True)) in self.output)
+                self.__do_alter_verify(pfmri_krb, verbose=True)
+
+                # Test that verify / fix on system wide could report / fix the
+                # error on the overlaid and overlaying packges.
+                self.file_remove(file_path)
+                self.pkg("verify", exit=1)
+                # Test that verify / fix on all packages should not emit the
+                # overlaying warning.
+                self.assertTrue("verify or fix" not in self.output)
+                self.pkg("fix")
+                self.assertTrue("verify or fix" not in self.output)
+                self.pkg("verify")
+                self.file_exists(file_path)
+
+                # Test different file types install. Since fix will repair the
+                # overlaid package in this case, we don't need to tell the users
+                # to look at the overlaying package.
+                self.pkg("-D broken-conflicting-action-handling=1 install "
+                    "dupfile duplink")
+                self.pkg("verify dupfile", exit=1)
+                self.pkg("fix dupfile")
+                self.pkg("verify dupfile")
+
+                # Test overlaid package that contains system attribute error.
+                self.set_img_path(tempfile.mkdtemp(prefix="test-suite",
+                    dir="/var/tmp"))
+                self.image_create(self.rurl)
+                self.pkg("install sysattr")
+                fpath = os.path.join(self.img_path(), "amber1")
+
+                # Install the overlaying package.
+                self.pkg("install sysattr_overlay")
+                portable.remove(fpath)
+                portable.copyfile(os.path.join(self.test_root, "amber1"),
+                    fpath)
+                os.chmod(fpath, 0o555)
+                os.chown(fpath, -1, 2)
+                self.pkg("verify sysattr", exit=1)
+                self.pkg("fix -v sysattr", exit=4)
+                self.assertTrue("Could not repair: {0}".format(pfmri_sysattr) in
+                    self.output, self.plist)
+                self.assertTrue("package: {0}".format(
+                    pfmri_sysattr_o.get_pkg_stem(anarchy=True)) in self.output)
+                self.pkg("fix sysattr_overlay")
+                self.pkg("verify sysattr")
+                self.image_destroy()
 
 if __name__ == "__main__":
         unittest.main()

--- a/src/tests/cli/t_fix.py
+++ b/src/tests/cli/t_fix.py
@@ -20,7 +20,7 @@
 # CDDL HEADER END
 #
 
-# Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
 
 from . import testutils
 if __name__ == "__main__":
@@ -33,6 +33,7 @@ import pkg.manifest as manifest
 import pkg.portable as portable
 import pkg.misc as misc
 import shutil
+import simplejson as json
 import tempfile
 import time
 import unittest
@@ -177,6 +178,29 @@ class TestFix(pkg5unittest.SingleDepotTestCase):
                 self.image_create(self.rurl)
                 self.pkg("install amber@1.0")
 
+                # Test invalid option combo.
+                self.pkg("fix -v --parsable 0 foo", exit=2)
+                self.pkg("fix -H --parsable 0 foo", exit=2)
+                # Test invalid option value.
+                self.pkg("fix --parsable 1 foo", exit=2)
+
+                # Test parsable output.
+                self.pkg("fix --parsable 0 amber", exit=4)
+                out_json = json.loads(self.output)
+                item_id = list(out_json["item-messages"].keys())[0]
+                self.assertTrue(
+                    out_json["item-messages"][item_id]["messages"][0]["msg_level"]
+                    == "info")
+
+                # Test unpackaged option.
+                self.pkg("fix --unpackaged", exit=4)
+                self.pkg("fix --parsable 0 --unpackaged", exit=4)
+                out_json = json.loads(self.output)
+                subitem_id = list(out_json["item-messages"]["unpackaged"].keys())[0]
+                self.assertTrue(
+                    out_json["item-messages"]["unpackaged"][subitem_id][0]["msg_level"]
+                    == "info")
+
                 index_dir = self.get_img_api_obj().img.index_dir
                 index_file = os.path.join(index_dir, "main_dict.ascii.v2")
                 orig_mtime = os.stat(index_file).st_mtime
@@ -195,6 +219,10 @@ class TestFix(pkg5unittest.SingleDepotTestCase):
 
                 # Verify that unprivileged users are handled by fix.
                 self.pkg("fix amber", exit=1, su_wrap=True)
+
+                self.pkg("fix --unpackaged -nv amber")
+                self.assertTrue("----" in self.output and "UNPACKAGED" in
+                    self.output)
 
                 # Fix the package
                 self.pkg("fix amber")

--- a/src/tests/cli/t_pkg_help.py
+++ b/src/tests/cli/t_pkg_help.py
@@ -20,7 +20,7 @@
 # CDDL HEADER END
 #
 
-# Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
 
 from . import testutils
 if __name__ == "__main__":
@@ -68,7 +68,8 @@ class TestPkgHelp(pkg5unittest.CliTestCase):
                         ret, out, err = self.pkg(option, out=True, stderr=True)
                         verify_help(err,
                             ["pkg [options] command [cmd_options] [operands]",
-                            "pkg verify [-Hqv] [pkg_fmri_pattern ...]",
+                            "pkg verify [-Hqv] [--parsable version] [--unpackaged]\n"
+                            "            [--unpackaged-only] [pkg_fmri_pattern ...]",
                             "PKG_IMAGE", "Usage:"])
 
                 # Invalid subcommands, ensuring we exit 2

--- a/src/tests/cli/t_pkg_verify.py
+++ b/src/tests/cli/t_pkg_verify.py
@@ -189,10 +189,16 @@ class TestPkgVerify(pkg5unittest.SingleDepotTestCase):
                 # Verify should find the extra alias and it should be treated
                 # as a warning.
                 self.pkg_verify("-v foo")
-                self.assertTrue("4321" in self.output)
+                #self.assertTrue("4321" in self.output)
+                self.assert_("4321" in self.output and "WARNING" in self.output)
 
-                # ...but it should not be treated as a fatal error.
+                # Test that warnings are displayed by default.
                 self.pkg_verify("foo")
+                self.assert_("4321" in self.output and "WARNING" in self.output)
+
+                # Vefify on system wide should also find the extra alias.
+                self.pkg_verify("")
+                self.assert_("4321" in self.output and "WARNING" in self.output)
 
         def test_02_installed(self):
                 """When multiple FMRIs are given to pkg verify, if any of them

--- a/src/tests/cli/t_pkg_verify.py
+++ b/src/tests/cli/t_pkg_verify.py
@@ -20,7 +20,7 @@
 # CDDL HEADER END
 #
 
-# Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
 
 from . import testutils
 if __name__ == "__main__":
@@ -30,18 +30,18 @@ import pkg5unittest
 import os
 import pkg.portable as portable
 import shutil
+import simplejson as json
 import subprocess
 import tempfile
 import time
 import unittest
-
 
 class TestPkgVerify(pkg5unittest.SingleDepotTestCase):
         # Tests in this suite use the read only data directory
         need_ro_data = True
 
         foo10 = """
-            open foo@1.0,5.11-0
+            open foo@1.0,5.11-0:20160229T095441Z
             add dir mode=0755 owner=root group=sys path=/etc
             add dir mode=0755 owner=root group=sys path=/etc/security
             add dir mode=0755 owner=root group=sys path=/usr
@@ -190,15 +190,15 @@ class TestPkgVerify(pkg5unittest.SingleDepotTestCase):
                 # as a warning.
                 self.pkg_verify("-v foo")
                 #self.assertTrue("4321" in self.output)
-                self.assert_("4321" in self.output and "WARNING" in self.output)
+                self.assertTrue("4321" in self.output and "WARNING" in self.output)
 
                 # Test that warnings are displayed by default.
                 self.pkg_verify("foo")
-                self.assert_("4321" in self.output and "WARNING" in self.output)
+                self.assertTrue("4321" in self.output and "WARNING" in self.output)
 
-                # Vefify on system wide should also find the extra alias.
+                # Verify on system wide should also find the extra alias.
                 self.pkg_verify("")
-                self.assert_("4321" in self.output and "WARNING" in self.output)
+                self.assertTrue("4321" in self.output and "WARNING" in self.output)
 
         def test_02_installed(self):
                 """When multiple FMRIs are given to pkg verify, if any of them
@@ -302,7 +302,141 @@ class TestPkgVerify(pkg5unittest.SingleDepotTestCase):
                 self.pkg("install foo")
 
                 self.pkg_verify("foo@invalid", exit=1)
-                self.assertTrue("illegal fmri" in self.errout)
+                self.assertTrue("verify" in self.errout and "illegal" in
+                    self.errout)
+
+        def test_verify_parsable_output(self):
+                """Test parsable output."""
+
+                self.image_create(self.rurl)
+                self.pkg("install foo")
+                # Test invalid option combo.
+                self.pkg_verify("-v --parsable 0 foo", exit=2)
+                self.pkg_verify("-H --parsable 0 foo", exit=2)
+                # Test invalid option value.
+                self.pkg_verify("--parsable 1 foo", exit=2)
+                self.pkg_verify("--parsable 0 foo")
+                out_json = json.loads(self.output)
+                self.assertTrue("pkg://test/foo@1.0,5.11-0:20160229T095441Z"
+                    in out_json["item-messages"])
+                fmri_entry = out_json["item-messages"][
+                    "pkg://test/foo@1.0,5.11-0:20160229T095441Z"]
+                self.assertTrue(fmri_entry["messages"][0]["msg_level"]
+                    == "info")
+                self.assertTrue("file: usr/bin/bobcat" in fmri_entry)
+
+                # Verify should fail if file is missing.
+                fpath = os.path.join(self.get_img_path(), "usr", "bin",
+                    "bobcat")
+                portable.remove(fpath)
+                self.pkg_verify("--parsable 0 foo", exit=1)
+                out_json = json.loads(self.output)
+                self.assertTrue("pkg://test/foo@1.0,5.11-0:20160229T095441Z"
+                    in out_json["item-messages"])
+                fmri_entry = out_json["item-messages"][
+                    "pkg://test/foo@1.0,5.11-0:20160229T095441Z"]
+                self.assertTrue(fmri_entry["messages"][0]["msg_type"]
+                    == "general")
+                self.assertTrue(fmri_entry["messages"][0]["msg_level"]
+                    == "error")
+                self.assertTrue("file: usr/bin/bobcat" in fmri_entry)
+                self.assertTrue(fmri_entry["file: usr/bin/bobcat"][0]["msg_type"]
+                    == "general")
+                self.assertTrue(fmri_entry["file: usr/bin/bobcat"][0]["msg_level"]
+                    == "error")
+
+        def test_unpackaged(self):
+                """Test unpackaged option."""
+
+                self.image_create(self.rurl)
+                self.pkg("install foo")
+                self.pkg_verify("--unpackaged")
+                self.assertTrue("ERROR" not in self.output and
+                    "WARNING" not in self.output and "Unpackaged" in
+                    self.output and "UNPACKAGED" in self.output)
+                self.assertTrue("----" not in self.output)
+                # Test verbose.
+                self.pkg_verify("-v --unpackaged")
+                self.assertTrue("----" in self.output)
+                self.assertTrue("ERROR" not in self.output and
+                    "WARNING" not in self.output and "Unpackaged" in
+                    self.output and "UNPACKAGED" in self.output)
+                self.assertTrue("ERROR" not in self.output and
+                    "WARNING" not in self.output and "bobcat" in
+                    self.output and "UNPACKAGED" in self.output)
+                # Test omit header.
+                self.pkg_verify("--unpackaged -H")
+                self.assertTrue("----" not in self.output)
+                self.assertTrue("ERROR" not in self.output and
+                    "WARNING" not in self.output and "Unpackaged" in
+                    self.output and "UNPACKAGED" not in self.output)
+                # Test unpackaged only.
+                self.pkg_verify("--unpackaged-only -v")
+                self.assertTrue("----" not in self.output)
+                self.assertTrue("ERROR" not in self.output and
+                    "WARNING" not in self.output and "Unpackaged" in
+                    self.output and "UNPACKAGED" in self.output)
+                self.assertTrue("ERROR" not in self.output and
+                    "WARNING" not in self.output and "Unpackaged" in
+                    self.output and "bobcat" not in self.output)
+
+                # Test quiet result.
+                self.pkg_verify("-q --unpackaged")
+                self.assertTrue(not self.output)
+
+                # Test invalid usage.
+                self.pkg_verify("--unpackaged-only foo", exit=2)
+                self.pkg_verify("--unpackaged --unpackaged-only", exit=2)
+                self.pkg_verify("-H --parsable 0 --unpackaged", exit=2)
+
+                # Test --unpackaged with package arguments.
+                self.pkg_verify("--unpackaged -v foo")
+                self.assertTrue("----" in self.output and "bobcat" in
+                    self.output and "UNPACKAGED" in self.output)
+                self.pkg_verify("--parsable 0 --unpackaged foo")
+                out_json = json.loads(self.output)
+                self.assertTrue("pkg://test/foo@1.0,5.11-0:20160229T095441Z"
+                    in out_json["item-messages"])
+                fmri_entry = out_json["item-messages"][
+                    "pkg://test/foo@1.0,5.11-0:20160229T095441Z"]
+                self.assertTrue(fmri_entry["messages"][0]["msg_level"]
+                    == "info")
+                self.assertTrue("file: usr/bin/bobcat" in fmri_entry)
+
+                # Test parsable output for --unpackaged.
+                self.pkg_verify("--parsable 0 --unpackaged")
+                out_json = json.loads(self.output)
+                self.assertTrue("unpackaged" in out_json["item-messages"]
+                    and out_json["item-messages"]["unpackaged"])
+                out_entry = out_json["item-messages"]["unpackaged"]
+                self.assertTrue("dir" in list(out_entry.keys())[0] or "file" in
+                    out_entry.keys()[0])
+                self.assertTrue(out_entry[list(out_entry.keys())[0]][0]["msg_level"]
+                    == "info")
+                self.assertTrue(out_entry[list(out_entry.keys())[0]][0]["msg_type"]
+                    == "unpackaged")
+                self.assertTrue("pkg://test/foo@1.0,5.11-0:20160229T095441Z"
+                    in out_json["item-messages"])
+                fmri_entry = out_json["item-messages"][
+                    "pkg://test/foo@1.0,5.11-0:20160229T095441Z"]
+                self.assertTrue(fmri_entry["messages"][0]["msg_level"]
+                    == "info")
+                self.assertTrue("file: usr/bin/bobcat" in fmri_entry)
+
+                # Test parsable output for --unpackaged-only.
+                self.pkg_verify("--parsable 0 --unpackaged-only")
+                out_json = json.loads(self.output)
+                self.assertTrue("unpackaged" in out_json["item-messages"]
+                    and out_json["item-messages"]["unpackaged"])
+                out_entry = out_json["item-messages"]["unpackaged"]
+                self.assertTrue("dir" in list(out_entry.keys())[0] or "file" in
+                    out_entry.keys()[0])
+                self.assertTrue(out_entry[list(out_entry.keys())[0]][0]["msg_level"]
+                    == "info")
+                self.assertTrue(out_entry[list(out_entry.keys())[0]][0]["msg_type"]
+                    == "unpackaged")
+                self.assertTrue("pkg://test/foo@1.0,5.11-0:20160229T095441Z"
+                    not in out_json["item-messages"])
 
 if __name__ == "__main__":
         unittest.main()

--- a/src/tests/pkg5unittest.py
+++ b/src/tests/pkg5unittest.py
@@ -1041,6 +1041,10 @@ if __name__ == "__main__":
                 # is correct.
                 self.assertTrue("space-required" in outd)
                 del outd["space-required"]
+                # Do not check item-messages, since it will be checked
+                # somewhere else.
+                self.assertTrue("item-messages" in outd)
+                del outd["item-messages"]
                 # Add 4 to account for self, output, include, and outd.
                 self.assertEqual(len(expected), len(outd) + 4, "Got a "
                     "different set of keys for expected and outd.  Those in "


### PR DESCRIPTION
More catching up with old commits and aligning the API version so we are ready to catch up with upstream.

This adds `pkg verify --unpackaged[-only]` and `pkg verify --parsable`.. interesting to be able to quickly list unpackaged files and will be useful for checking freshly installed systems when we prepare releases.

```
bloody:pkg5:verify% PYTHONPATH=proto/root_i386/usr/lib/python2.7/vendor-packages pfexec python2 src/client.py verify --unpackaged
PACKAGE                                                                 STATUS
pkg://omnios/shell/zsh                                                   ERROR
        file: etc/zshrc
                ERROR: Size: 485 bytes should be 1043
                ERROR: Hash: 605420c52eee95e27ca502694ba12f45399c2a97 should be 29614bba2c8afecd432287e8c162b81125857357
--------------------------------------------------------------------------------
UNPACKAGED CONTENTS
file: /tmpgGWxFT:
        Unpackaged file
file: /devices/pseudo/nsmb@0:nsmb:
        Unpackaged file
file: /etc/zones/sparse.xml:
        Unpackaged file
file: /etc/inet/static_routes:
        Unpackaged file
... elided ...
```

```
bloody:pkg5:verify% PYTHONPATH=proto/root_i386/usr/lib/python2.7/vendor-packages pfexec python2 src/client.py verify --parsable 0 zsh
{"image-name": null, "affect-services": [], "licenses": [], "child-images": [], "change-mediators": [], "change-facets": [], "remove-packages": [], "be-name": null, "space-available": 253666076672, "boot-archive-rebuild": false, "version": 0, "create-new-be": false, "change-packages": [], "space-required": 4950146.25, "change-variants": [], "affect-packages": ["pkg://omnios/shell/zsh@5.5.1,5.11-0.151027:20180818T082749Z"], "item-messages": {"pkg://omnios/shell/zsh@5.5.1,5.11-0.151027:20180818T082749Z": {"messages": [{"msg_time": "20180824T094731Z", "msg_text": "pkg://omnios/shell/zsh                                                   ERROR", "msg_type": "general", "msg_level": "error"}], "file: etc/zshrc": [{"msg_time": "20180824T094731Z", "msg_text": "ERROR: Size: 485 bytes should be 1043", "msg_type": "general", "msg_level": "error"}, {"msg_time": "20180824T094731Z", "msg_text": "ERROR: Hash: 605420c52eee95e27ca502694ba12f45399c2a97 should be 29614bba2c8afecd432287e8c162b81125857357", "msg_type": "general", "msg_level": "error"}]}}, "change-editables": [], "create-backup-be": false, "release-notes": [], "add-packages": [], "backup-be-name": null, "activate-be": true}
```