### PR TITLE
Improve message about required reboot

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -693,13 +693,21 @@ def __display_plan(api_inst, verbose, noexecute, op=None):
                 # Warn the user since this isn't likely what they wanted.
                 if plan.new_be:
                         logger.warning(_("""\
-WARNING: The boot environment being modified is not the active one.  Changes
-made in the active BE will not be reflected on the next boot.
+
+******************************************************************************
+WARNING: The boot environment being modified is not the active one.
+         Changes made in the active BE will not be reflected on the next boot.
+******************************************************************************
+
 """))
                 else:
                         logger.warning(_("""\
-WARNING: The boot environment being modified is not the active one.  Changes
-made will not be reflected on the next boot.
+
+******************************************************************************
+WARNING: The boot environment being modified is not the active one.
+         Changes made will not be reflected on the next boot.
+******************************************************************************
+
 """))
 
         a, r, i, c = [], [], [], []

--- a/src/modules/client/bootenv.py
+++ b/src/modules/client/bootenv.py
@@ -546,6 +546,9 @@ class BootEnv(object):
 A clone of {be_name} exists and has been updated and activated.
 On the next boot the Boot Environment {be_name_clone} will be
 mounted on '/'.  Reboot when ready to switch to this updated BE.
+
+*** Reboot required ***
+New BE: {be_name_clone}
 """).format(**self.__dict__))
                         else:
                                 logger.info(_("""


### PR DESCRIPTION
People often miss the fact that a reboot is required following an update as it is really hidden in a paragraph of text.

>A clone of 20180817 exists and has been updated and activated.
On the next boot the Boot Environment 20180817-1 will be
mounted on '/'.  Reboot when ready to switch to this updated BE.

which looks pretty similar to other messages that come out of pkg. I also find it hard to see the new BE name clearly in that text. I'm adding a couple of new lines to the output indicating that a reboot is required and showing the new BE name.

```
bloody:pkg5:be% PYTHONPATH=../proto/root_i386/usr/lib/python2.7/vendor-packages pfexec python2 ./client.py update --require-new-be
            Packages to update:   9
       Create boot environment: Yes
Create backup boot environment:  No

DOWNLOAD                                PKGS         FILES    XFER (MB)   SPEED
Completed                                9/9       384/384      3.4/3.4  438k/s

PHASE                                          ITEMS
Removing old actions                           40/40
Installing new actions                         37/37
Updating modified actions                    642/642
Updating package state database                 Done
Updating package cache                           9/9
Updating image state                            Done
Creating fast lookup database                   Done
Reading search index                            Done
Updating search index                            9/9

A clone of 20180817 exists and has been updated and activated.
On the next boot the Boot Environment 20180817-1 will be
mounted on '/'.  Reboot when ready to switch to this updated BE.

*** Reboot required ***
New BE: 20180817-1

-------------------------------------------------------------------------------
Find release notes:                        https://omniosce.org/releasenotes
-------------------------------------------------------------------------------
Get a support contract:                    https://omniosce.org/support
Sponsor OmniOS development:                https://omniosce.org/patron
Contribute to OmniOS:                      https://omniosce.org/joinus
-------------------------------------------------------------------------------
```