### PR TITLE
Set default hostbridge to amd

### DIFF
--- a/src/brand/bhyve/init
+++ b/src/brand/bhyve/init
@@ -31,7 +31,7 @@ opts = {
     'ram':          '1G',
     'bootrom':      'BHYVE_RELEASE_CSM',
     'bootorder':    'cd',
-    'hostbridge':   'default',
+    'hostbridge':   'amd',
     'diskif':       'virtio-blk',
     'netif':        'virtio-net-viona',
     'type':         'generic',


### PR DESCRIPTION
https://wiki.freebsd.org/bhyve/OpenBSD

"Slot 0 should use amd_hostbridge for all OpenBSD instances, even on Intel based hardware as MSI/MSI-x interrupts which are used by the xhci/tablet for accurate mouse control are not available in OpenBSD unless the hostbridge is advertised as AMD."

amd hostbridge is required for at least OpenBSD and does no harm for other operating systems. We should use amd for the default - the administrator can still override via the `hostbridge` zone attribute.