### PR TITLE
Do not restart init on failure in kvm/bhyve zones

### DIFF
--- a/src/brand/bhyve/config.xml
+++ b/src/brand/bhyve/config.xml
@@ -22,6 +22,7 @@
 	<modname></modname>
 
 	<initname>/usr/lib/brand/bhyve/init</initname>
+	<restartinit>false</restartinit>
 	<login_cmd />
 	<forcedlogin_cmd />
 	<user_cmd />

--- a/src/brand/kvm/config.xml
+++ b/src/brand/kvm/config.xml
@@ -22,6 +22,7 @@
 	<modname></modname>
 
 	<initname>/usr/lib/brand/kvm/init</initname>
+	<restartinit>false</restartinit>
 	<login_cmd />
 	<forcedlogin_cmd />
 	<user_cmd />


### PR DESCRIPTION
At present, when `init` detects a power off or halt and exits, zoneadmd just restarts it. This parameter causes init to be launched just once; init itself controls rebooting the VM when required.