### PR TITLE
Add overlays to sparse zone vfstab (r151026)

### DIFF
--- a/src/brand/sparse/common.ksh
+++ b/src/brand/sparse/common.ksh
@@ -68,6 +68,14 @@ mount_overlays()
 			touch $keyf
 			/bin/chmod S+vimmutable $keyf
 		fi
+		if ! egrep -s "^$ACTIVE_DS/$ds " $ZONEPATH/root/etc/vfstab; then
+			# Add the overlay to the zone vfstab. This ensures that
+			# it is properly mounted when mounting alternate
+			# BEs, such as when doing new-be pkg update.
+			cat <<- EOM >> $ZONEPATH/root/etc/vfstab
+				$ACTIVE_DS/$ds - /$mp zfs - no -
+			EOM
+		fi
 	done
 }
 

--- a/src/modules/client/image.py
+++ b/src/modules/client/image.py
@@ -574,7 +574,7 @@ in the environment or by setting simulate_cmdpath in DebugValues.""")
                             self.imgdir, self.transport,
                             self.cfg.get_policy("use-system-repo"))
 
-                if self.version == self.CURRENT_VERSION:
+                if self.cfg.version == imageconfig.CURRENT_VERSION:
                         for keyf in self.get_property(imageconfig.KEY_FILES):
                                 if not os.path.exists(
                                     self.root + os.path.sep + keyf):


### PR DESCRIPTION
Backport for #88 
Also fixing the behaviour of the `key-files` property to prevent upgrades appearing to work when they do not fully complete.