### PR TITLE
Python3 sort cannot handle None

### DIFF
--- a/src/modules/publish/dependencies.py
+++ b/src/modules/publish/dependencies.py
@@ -1417,7 +1417,7 @@ def __remove_extraneous_conditionals(deps, omitted_req_any):
                     include_scheme=False)
 
         def path_id_attrget(d):
-                return d[0].attrs.get(path_id_prefix, None)
+                return d[0].attrs.get(path_id_prefix, '')
 
         req_dict = {}
         for target, group in itertools.groupby(sorted(


### PR DESCRIPTION
Found during illumos build with python3 pkg.

```
Generating dependencies for system-library-python-zfs-3.mog
Resolving dependencies
Traceback (most recent call last):
  File "/usr/bin/pkgdepend", line 601, in <module>
    __ret = main_func()
  File "/usr/bin/pkgdepend", line 580, in main_func
    return resolve(pargs, img_dir)
  File "/usr/bin/pkgdepend", line 338, in resolve
    system_patterns, prune_attrs=not verbose)
  File "/usr/lib/python3.5/vendor-packages/pkg/publish/dependencies.py", line 1876, in resolve_deps
    pfmri, name_to_use)
  File "/usr/lib/python3.5/vendor-packages/pkg/publish/dependencies.py", line 1529, in combine
    res = __remove_extraneous_conditionals(res, omitted_require_any)
  File "/usr/lib/python3.5/vendor-packages/pkg/publish/dependencies.py", line 1431, in __remove_extraneous_conditionals
    key=path_id_attrget), path_id_attrget):
TypeError: unorderable types: NoneType() < NoneType()
```