### PR TITLE
Traceback when removing some packages (r151028)

### DIFF
--- a/src/modules/client/api.py
+++ b/src/modules/client/api.py
@@ -709,7 +709,7 @@ in the environment or by setting simulate_cmdpath in DebugValues.""")
                 release = date = None
                 # Check to see if release/name is being updated
                 for src, dest in self._img.imageplan.plan_desc:
-                        if dest.get_name() != 'release/name':
+                        if not dest or dest.get_name() != 'release/name':
                                 continue
                         # It is, extract attributes
                         for a in self._img.imageplan.pd.update_actions:


### PR DESCRIPTION
```
theeo# pkg uninstall system/bhyve

Traceback (most recent call last):
...
  File "/usr/lib/python2.7/vendor-packages/pkg/client/api.py", line 712, in __auto_be_name
    if dest.get_name() != 'release/name':
AttributeError: 'NoneType' object has no attribute 'get_name'
```