### PR TITLE
Fix derived version number

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -53,6 +53,7 @@ PYLINT_VER_CMD = PYTHONPATH= /usr/bin/pkg info $(PYLINT_FMRI) | \
 
 PEP8 = /usr/bin/pep8
 JOBS = 8
+CC = /opt/gcc-4.4.4/bin/gcc
 
 SUBDIRS=brand zoneproxy tsol util/mkcert
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -1076,7 +1076,8 @@ def get_git_version():
                 p = subprocess.Popen(
                     ['git', 'show', '--format=%h', '--no-patch'],
                     stdout = subprocess.PIPE)
-                return p.communicate()[0].strip()
+                return p.communicate()[0].strip().decode('utf-8', 'strict')
+
         except OSError:
                 print("ERROR: unable to obtain git commit hash",
                     file=sys.stderr)


### PR DESCRIPTION
With the switch to python3, the package version number is now derived as a bytes type rather than a string. This adds an extra b'...' around the version which is show by `pkg version` and set as the user-agent in requests to the package server.
```
bloody:pkg5:master% grep VERSION /usr/lib/python3.5/vendor-packages/pkg/__init__.py
VERSION = "b'c5d21b30'"
```

```
bloody:pkg5:ver% grep VERSION ../proto/root_i386/usr/lib/python3.5/vendor-packages/pkg/__init__.py
VERSION = "c5d21b30f"
```

Also setting a default compiler - to gcc4 since at present the linking tests do not work with a newer gcc version.