### PR TITLE
Provide option to specify disk slot for bhyve/kvm zones

### DIFF
--- a/doc/bhyve.md
+++ b/doc/bhyve.md
@@ -18,23 +18,25 @@ which will be created at `/path/to/zone/root/tmp/init.log`
 | acpi		| on			| on,off
 | bootdisk<sup>1</sup>	| 			| path[,serial=<serno>] | tank/hdd/bhyve1
 | bootorder	| cd			| \[c\]\[d\]
-| bootrom<sup>2</sup>	| BHYVE_RELEASE_CSM	| firmware name\|path to firmware | BHYVE_DEBUG_CSM
-| cdrom<sup>3</sup>		|			| path to ISO		  | /data/iso/FreeBSD-11.1-RELEASE-amd64-bootonly.iso
-| console	| /dev/zconsole<sup>5</sup>	| options		| socket,/tmp/vm.com1,wait
+| bootrom<sup>3</sup>	| BHYVE_RELEASE_CSM	| firmware name\|path to firmware | BHYVE_DEBUG_CSM
+| cdrom<sup>4</sup>		|			| path to ISO		  | /data/iso/FreeBSD-11.1-RELEASE-amd64-bootonly.iso
+| console	| /dev/zconsole<sup>6</sup>	| options		| socket,/tmp/vm.com1,wait
 | disk<sup>1</sup>		| 			| path[,serial=<serno>] | tank/hdd/bhyve2,serial=1234
+| diskN<sup>2</sup>		| 			| path[,serial=<serno>] | tank/hdd/bhyve2,serial=1234
 | diskif	| virtio-blk		| virtio-blk,ahci-hd
 | hostbridge	| i440fx		| i440fx,q35,amd,netapp,none
 | netif		| virtio-net-viona	| virtio-net-viona,e1000
 | ram		| 1G			| n(G\|M)		| 8G
 | type		| generic		| generic,windows,openbsd
 | vcpus		| 1			| [[cpus=]numcpus][,sockets=n][,cores=n][,threads=n]] | cpus=16,sockets=2,cores=4,threads=2
-| vnc<sup>4</sup>		| off			| off,on,options	| socket,/tmp/vm.vnc,w=1024,h=768,wait
+| vnc<sup>5</sup>		| off			| off,on,options	| socket,/tmp/vm.vnc,w=1024,h=768,wait
 | extra		|			| extra arguments for hypervisor |
 
 #### Notes
 
 <ol>
 <li>You will also need to pass the underlying disk device through to the zone via a <i>device</i> entry, see the example below;</li>
+<li>Use diskN to specify the slot into which the disk will be placed. A plain <i>disk</i> tag will be put in the lowest available slot.</li>
 <li>Available firmware files can be found in <i>/usr/share/bhyve/firmware/</i>;</li>
 <li>The ISO file needs passing through to the zone via a lofs mount, see the example below;</li>
 <li>Setting vnc to <i>on</i> is the same as setting it to <i>unix=/tmp/vm.vnc</i>.</li>
@@ -111,7 +113,7 @@ attr:
         type: string
         value: tank/hdd/bhyve1
 attr:
-        name: disk
+        name: disk1
         type: string
         value: tank/hdd/bhyve2,serial=1234
 attr:
@@ -187,7 +189,7 @@ set type=string
 set value=tank/hdd/bhyve1
 end
 add attr
-set name=disk
+set name=disk1
 set type=string
 set value=tank/hdd/bhyve2,serial=1234
 end

--- a/doc/kvm.md
+++ b/doc/kvm.md
@@ -17,22 +17,24 @@ which will be created at `/path/to/zone/root/tmp/init.log`
 | ---		| ---			| ---			| ---
 | bootdisk<sup>1</sup>	| 			| path[,serial=<serno>] | tank/hdd/kvm1
 | bootorder	| cd			| \[c\]\[d\]\[n\]
-| cdrom<sup>3</sup>		|			| path to ISO		  | /data/iso/FreeBSD-11.1-RELEASE-amd64-bootonly.iso
+| cdrom<sup>4</sup>		|			| path to ISO		  | /data/iso/FreeBSD-11.1-RELEASE-amd64-bootonly.iso
 | cpu		| qemu64		|
-| console	| pipe,id=console0,path=/dev/zconsole<sup>5</sup>	| options		|
+| console	| pipe,id=console0,path=/dev/zconsole<sup>6</sup>	| options		|
 | disk<sup>1</sup>		| 			| path[,serial=<serno>] | tank/hdd/kvm2,serial=1234
+| diskN<sup>2</sup>		| 			| path[,serial=<serno>] | tank/hdd/kvm2,serial=1234
 | diskif	| virtio		| virtio,ahci
 | netif		| virtio-net-pci	| virtio-net-pci,e1000
 | ram		| 1G			| n(G\|M)		| 8G
 | type		| generic		| generic
 | vcpus		| 1			|  n			| 16
-| vnc<sup>4</sup>		| off			| off,on,options	| unix:/tmp/vm.vnc
+| vnc<sup>5</sup>		| off			| off,on,options	| unix:/tmp/vm.vnc
 | extra		|			| extra arguments for hypervisor |
 
 #### Notes
 
 <ol>
 <li>You will also need to pass the underlying disk device through to the zone via a <i>device</i> entry, see the example below;</li>
+<li>Use diskN to specify the slot into which the disk will be placed. A plain <i>disk</i> tag will be put in the lowest available slot.</li>
 <li>Available firmware files can be found in <i>/usr/share/kvm/firmware/</i>;</li>
 <li>The ISO file needs passing through to the zone via a lofs mount, see the example below;</li>
 <li>Setting vnc to <i>on</i> is the same as setting it to <i>unix=/tmp/vm.vnc</i>.</li>
@@ -105,7 +107,7 @@ attr:
         type: string
         value: tank/hdd/oi1
 attr:
-        name: disk
+        name: disk1
         type: string
         value: tank/hdd/oi2,serial=1234
 ```
@@ -168,7 +170,7 @@ set type=string
 set value=tank/hdd/oi1
 end
 add attr
-set name=disk
+set name=disk1
 set type=string
 set value=tank/hdd/oi2,serial=1234
 end

--- a/src/brand/bhyve/init
+++ b/src/brand/bhyve/init
@@ -15,14 +15,32 @@
 
 # Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 
-import logging, os, subprocess, sys, time
+import logging, os, subprocess, sys, time, re, getopt
 import xml.etree.ElementTree as etree
 from pprint import pprint, pformat
 
-logging.basicConfig(filename='/tmp/init.log', filemode='w', level=logging.DEBUG)
-
 zonexml = '/etc/zone.xml'
 uuidfile = '/etc/uuid'
+testmode = False
+
+try:
+    opts, args = getopt.getopt(sys.argv[1:], "tx:u:")
+except getopt.GetoptError:
+    print("init [-t] [-x <xml file>] [-u <uuid file>]")
+    sys.exit(2)
+for opt, arg in opts:
+    if opt == '-t':
+        testmode = True
+    elif opt == '-x':
+        zonexml = arg
+    elif opt == '-u':
+        uuidfile = arg
+
+if testmode:
+    logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+else:
+    logging.basicConfig(filename='/tmp/init.log', filemode='w',
+        level=logging.DEBUG)
 
 # Default values
 opts = {
@@ -165,6 +183,8 @@ def diskpath(arg):
         return arg
     return '/dev/zvol/rdsk/{0}'.format(arg)
 
+# CDROM
+
 i = 0
 for cdrom in root.findall('./attr[@name="cdrom"]'):
     args.extend([
@@ -172,6 +192,8 @@ for cdrom in root.findall('./attr[@name="cdrom"]'):
             i, 'ahci-cd', cdrom.get('value').strip())
     ])
     i += 1
+
+# Bootdisk
 
 try:
     bootdisk = root.find('./attr[@name="bootdisk"]')
@@ -182,13 +204,36 @@ try:
 except:
     pass
 
-i = 0
+# Additional Disks
+
+# Look for disk attributes. These may be just "disk" or "diskN" to specify
+# the slot into which the disk should be placed. zonecfg does not allow the
+# addition of multiple attributes with the same name but manual edits to the
+# zone's XML file may have been made and so multiple disk attributes are
+# supported.
+disklist = {}
+for disk in root.findall('./attr[@name]'):
+    m = re.search(r'^disk(\d+)$', disk.get('name').strip())
+    if not m: continue
+    k = int(m.group(1))
+    if k in disklist:
+        logging.error(
+            'Disk {} appears more than once in configuration'.format(k))
+        sys.exit(1)
+    disklist[k] = disk.get('value').strip()
+
+# Now insert plain "disk" tags into the list, using available slots in order
+avail = sorted(set(range(0, 100)).difference(sorted(disklist.keys())))
 for disk in root.findall('./attr[@name="disk"]'):
+    disklist[avail.pop(0)] = disk.get('value').strip()
+
+logging.debug('Disk list: \n{}'.format(pformat(disklist)))
+
+for i, v in disklist.items():
     args.extend([
         '-s', '{0}:{1},{2},{3}'.format(DISK_SLOT,
-            i, opts['diskif'], diskpath(disk.get('value').strip()))
+            i, opts['diskif'], v)
     ])
-    i += 1
 
 # Network
 
@@ -222,6 +267,9 @@ args.append(name)
 
 logging.info('Final arguments: {0}'.format(pformat(args)))
 logging.info('{0}'.format(' '.join(args)))
+
+if testmode:
+    sys.exit(0)
 
 if os.path.exists('/dev/vmm/{0}'.format(name)):
     logging.info('Destroying old bhyve instance')

--- a/src/brand/kvm/init
+++ b/src/brand/kvm/init
@@ -15,14 +15,32 @@
 
 # Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 
-import logging, os, subprocess, sys, time
+import logging, os, subprocess, sys, time, re, getopt
 import xml.etree.ElementTree as etree
 from pprint import pprint, pformat
 
-logging.basicConfig(filename='/tmp/init.log', filemode='w', level=logging.DEBUG)
-
 zonexml = '/etc/zone.xml'
 uuidfile = '/etc/uuid'
+testmode = False
+
+try:
+    opts, args = getopt.getopt(sys.argv[1:], "tx:u:")
+except getopt.GetoptError:
+    print("init [-t] [-x <xml file>] [-u <uuid file>]")
+    sys.exit(2)
+for opt, arg in opts:
+    if opt == '-t':
+        testmode = True
+    elif opt == '-x':
+        zonexml = arg
+    elif opt == '-u':
+        uuidfile = arg
+
+if testmode:
+    logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+else:
+    logging.basicConfig(filename='/tmp/init.log', filemode='w',
+        level=logging.DEBUG)
 
 # Default values
 opts = {
@@ -113,38 +131,71 @@ def diskpath(arg):
         return arg
     return '/dev/zvol/rdsk/{0}'.format(arg)
 
-def add_disk(path, boot=False):
+def add_disk(path, boot=False, intf=None, media='disk', index=-1):
     global args
+
+    if not intf:
+        intf = opts['diskif']
+
+    if index < 0:
+        index = add_disk.index
+        add_disk.index += 1
+        logging.debug('BUMP INDEX')
+
     str = (
-        'file={0},if={1},media=disk,index={2},cache=none'
-            .format(diskpath(path), opts['diskif'], add_disk.index)
+        'file={0},if={1},media={2},index={3},cache=none'
+            .format(diskpath(path), intf, media, index)
     )
     if ',serial=' not in str:
-        str += ',serial={0}'.format(add_disk.index)
+        str += ',serial={0}'.format(index)
     if boot:
         str += ',boot=on'
     args.extend(['-drive', str])
-    add_disk.index += 1
 add_disk.index = 0
 
 try:
     cdrom = root.find('./attr[@name="cdrom"]')
-    args.extend([
-        '-drive',
-        'file={0},if=ide,media=cdrom,index=0,serial=0,cache=none'
-            .format(cdrom.get('value').strip())
-    ])
+    add_disk(cdrom.get('value').strip(), boot=False, intf='ide', media='cdrom')
 except:
     pass
+
+# If the disks are not using IDE, then reset their index as there is no need
+# to leave room for the CDROM.
+if opts['diskif'] != 'ide':
+    add_disk.index = 0
 
 try:
     bootdisk = root.find('./attr[@name="bootdisk"]')
-    add_disk(bootdisk.get('value').strip(), True)
+    add_disk(bootdisk.get('value').strip(), boot=True)
 except:
     pass
 
+# Look for disk attributes. These may be just "disk" or "diskN" to specify
+# the slot into which the disk should be placed. zonecfg does not allow the
+# addition of multiple attributes with the same name but manual edits to the
+# zone's XML file may have been made and so multiple disk attributes are
+# supported.
+disklist = {}
+for disk in root.findall('./attr[@name]'):
+    m = re.search(r'^disk(\d+)$', disk.get('name').strip())
+    if not m: continue
+    k = int(m.group(1))
+    if k in disklist or k < add_disk.index:
+        logging.error(
+            'Disk {} appears more than once in configuration'.format(k))
+        sys.exit(1)
+    disklist[k] = disk.get('value').strip()
+
+# Now insert plain "disk" tags into the list, using available slots in order
+avail = sorted(set(range(add_disk.index + 1, 100))
+    .difference(sorted(disklist.keys())))
 for disk in root.findall('./attr[@name="disk"]'):
-    add_disk(disk.get('value').strip())
+    disklist[avail.pop(0)] = disk.get('value').strip()
+
+logging.debug('Disk list: \n{}'.format(pformat(disklist)))
+
+for i, v in disklist.items():
+    add_disk(v, index=i)
 
 # Network
 
@@ -185,6 +236,9 @@ if len(opts['extra']):
 
 logging.info('Final arguments: {0}'.format(pformat(args)))
 logging.info('{0}'.format(' '.join(args)))
+
+if testmode:
+    sys.exit(0)
 
 while True:
     logging.info('Starting kvm')


### PR DESCRIPTION
Support multiple disks via 'diskN' attribute name

It has been reported that the `zonecfg` command does not permit the addition of more than one attribute with the name `disk` which stops the use of more than one extra disk with bhyve or kvm. It is possible to get around this by manually editing the zone configuration XML file but a better solution is needed. It is also desirable to enable disk slot persistence.

This change adds new `diskN` attributes to both brands that can be used to add multiple disks and specify the slot into which they should be placed. Since existing configurations will exist containing multiple "disk" attributes, this is also supported. In this case, the plain attribute disks are placed into available slots in ascending order, after allocating the numbered disks.

For example, this configuration:
```xml
  <attr name="disk" type="string" value="data/plain1"/>
  <attr name="disk" type="string" value="data/plain2"/>
  <attr name="disk" type="string" value="data/plain3"/>
  <attr name="disk0" type="string" value="data/fred"/>
  <attr name="disk1" type="string" value="data/willma"/>
  <attr name="disk2" type="string" value="data/betty"/>
  <attr name="disk3" type="string" value="data/barney"/>
```
yields:

```
 '-s', '5:0,virtio-blk,data/fred',
 '-s', '5:1,virtio-blk,data/willma',
 '-s', '5:2,virtio-blk,data/betty',
 '-s', '5:3,virtio-blk,data/barney',
 '-s', '5:4,virtio-blk,data/plain1',
 '-s', '5:5,virtio-blk,data/plain2',
 '-s', '5:6,virtio-blk,data/plain3',
```

This:
```xml
  <attr name="disk" type="string" value="data/plain1"/>
  <attr name="disk" type="string" value="data/plain2"/>
  <attr name="disk" type="string" value="data/plain3"/>
  <attr name="disk2" type="string" value="data/fred"/>
  <attr name="disk5" type="string" value="data/willma"/>
  <attr name="disk6" type="string" value="data/betty"/>
  <attr name="disk7" type="string" value="data/barney"/>
```
gives rise to:
```
 '-s', '5:0,virtio-blk,data/plain1',
 '-s', '5:1,virtio-blk,data/plain2',
 '-s', '5:2,virtio-blk,data/fred',
 '-s', '5:3,virtio-blk,data/plain3',
 '-s', '5:5,virtio-blk,data/willma',
 '-s', '5:6,virtio-blk,data/betty',
 '-s', '5:7,virtio-blk,data/barney',
```
and, finally, this:
```xml
  <attr name="disk" type="string" value="data/plain1"/>
  <attr name="disk1" type="string" value="data/fred"/>
  <attr name="disk2" type="string" value="data/willma"/>
  <attr name="disk" type="string" value="data/plain2"/>
```
results in:
```
 '-s', '5:0,virtio-blk,data/plain1',
 '-s', '5:1,virtio-blk,data/fred',
 '-s', '5:2,virtio-blk,data/willma',
 '-s', '5:3,virtio-blk,data/plain2',
```