### PR TITLE
Allow relative disk paths in bhyve brand

### DIFF
--- a/src/brand/bhyve/init
+++ b/src/brand/bhyve/init
@@ -231,8 +231,8 @@ logging.debug('Disk list: \n{}'.format(pformat(disklist)))
 
 for i, v in disklist.items():
     args.extend([
-        '-s', '{0}:{1},{2},{3}'.format(DISK_SLOT,
-            i, opts['diskif'], v)
+        '-s', '{0}:{1},{2},{3}'.format(DISK_SLOT, i, opts['diskif'],
+        diskpath(v))
     ])
 
 # Network


### PR DESCRIPTION
#102 broke the option to specify disks using just the dataset name in bhyve brands.