### PR TITLE
kvm brand should not overwrite cdrom paths (r151028)

### DIFF
--- a/src/brand/kvm/init
+++ b/src/brand/kvm/init
@@ -127,7 +127,7 @@ args.extend([
 # Disks
 
 def diskpath(arg):
-    if arg.startswith('/dev/zvol/rdsk'):
+    if arg.startswith('/'):
         return arg
     return '/dev/zvol/rdsk/{0}'.format(arg)
 


### PR DESCRIPTION
Backport for #105 