### PR TITLE
pkgrecv should use HTTP/1.1

### DIFF
--- a/src/modules/client/transport/engine.py
+++ b/src/modules/client/transport/engine.py
@@ -809,6 +809,9 @@ class CurlTransportEngine(TransportEngine):
                 hdl.setopt(pycurl.MAXREDIRS,
                     global_settings.PKG_CLIENT_MAX_REDIRECT)
 
+                # Use HTTP/1.1
+                hdl.setopt(pycurl.HTTP_VERSION, pycurl.CURL_HTTP_VERSION_1_1)
+
                 # Store the proxy in the handle so it can be used to retrieve
                 # transport statistics later.
                 hdl.proxy = None


### PR DESCRIPTION
we currently had issues publishing packages via `pkgrecv` due to enabling HTTP/2 on our pkg webserver. while the reverse_proxy module only supports HTTP/1.1 the server advertises HTTP/2 and therefore the client starts to send HTTP/2 traffic. This fix sets the client HTTP version to 1.1.

Needs to be backported to all supported releases.