### PR TITLE
Update tests to handle building with newer gcc

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -53,7 +53,7 @@ PYLINT_VER_CMD = PYTHONPATH= /usr/bin/pkg info $(PYLINT_FMRI) | \
 
 PEP8 = /usr/bin/pep8
 JOBS = 8
-CC = /opt/gcc-4.4.4/bin/gcc
+CC = gcc
 
 SUBDIRS=brand zoneproxy tsol util/mkcert
 

--- a/src/modules/flavor/elf.py
+++ b/src/modules/flavor/elf.py
@@ -24,7 +24,7 @@
 # Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
 #
 
-import os
+import os, re
 
 import pkg.elf as elf
 import pkg.flavor.base as base
@@ -202,7 +202,8 @@ def process_elf_dependencies(action, pkg_vars, dyn_tok_conv, run_paths,
             installed_path.startswith("usr/kernel") or \
             (installed_path.startswith("platform") and \
             installed_path.split("/")[2] == "kernel"):
-                if rp:
+                if rp and (len(rp) > 1 or
+                    not re.match(r'^/usr/gcc/\d/lib$', rp[0])):
                         raise RuntimeError("RUNPATH set for kernel module "
                             "({0}): {1}".format(installed_path, rp))
                 # Add this platform to the search path.

--- a/src/tests/api/t_dependencies.py
+++ b/src/tests/api/t_dependencies.py
@@ -29,6 +29,7 @@ if __name__ == "__main__":
 import pkg5unittest
 
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -1104,6 +1105,15 @@ file NOHASH group=sys mode=0755 owner=root path={runpath_mod_path}
 file NOHASH group=sys mode=0755 owner=root path={runpath_mod_test_path}
 """.format(**paths)
 
+        def glfilter(self, s):
+                return set([x for x in s if not re.match(r'usr/gcc/\d/', x)])
+
+        def tpfilter(self, s):
+                _p, _d = s
+                _d = tuple([x for x in _d
+                    if not re.match(r'^usr/gcc/\d/lib$', x)])
+                return (_p, _d)
+
         def setUp(self):
                 pkg5unittest.Pkg5TestCase.setUp(self)
 
@@ -1277,8 +1287,8 @@ file NOHASH group=sys mode=0755 owner=root path={runpath_mod_test_path}
                 self.assertTrue(d.is_error())
                 self.assertTrue(d.dep_vars.is_satisfied())
                 self.assertEqual(d.base_names[0], "libc.so.1")
-                self.assertEqual(set(d.run_paths), set(["lib",
-                    "usr/lib"]))
+                self.assertEqual(self.glfilter(set(d.run_paths)),
+                    set(["lib", "usr/lib"]))
 
                 # Check that internal dependencies are as expected.
                 ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
@@ -1293,7 +1303,7 @@ file NOHASH group=sys mode=0755 owner=root path={runpath_mod_test_path}
                             self.paths["ksh_path"]):
                                 self.assertEqual(d.action.attrs["path"],
                                     self.paths["script_path"])
-                        elif d.dep_key() == self.__path_to_key(
+                        elif self.tpfilter(d.dep_key()) == self.__path_to_key(
                             self.paths["libc_path"]):
                                 self.assertEqual(d.action.attrs["path"],
                                     self.paths["ksh_path"])
@@ -1316,9 +1326,9 @@ file NOHASH group=sys mode=0755 owner=root path={runpath_mod_test_path}
                         self.assertTrue(d.is_error())
                         self.assertTrue(d.dep_vars.is_satisfied())
                         self.assertEqual(d.base_names[0], "libc.so.1")
-                        self.assertEqual(set(d.run_paths),
+                        self.assertEqual(self.glfilter(set(d.run_paths)),
                             set(["lib", "usr/lib"]))
-                        self.assertEqual(d.dep_key(),
+                        self.assertEqual(self.tpfilter(d.dep_key()),
                             self.__path_to_key(self.paths["libc_path"]))
                         self.assertEqual(
                                 d.action.attrs["path"],
@@ -1349,9 +1359,9 @@ file NOHASH group=sys mode=0755 owner=root path={runpath_mod_test_path}
                         self.assertTrue(d.is_error())
                         self.assertTrue(d.dep_vars.is_satisfied())
                         self.assertEqual(d.base_names[0], "libc.so.1")
-                        self.assertEqual(set(d.run_paths),
+                        self.assertEqual(self.glfilter(set(d.run_paths)),
                             set(["lib", "usr/lib"]))
-                        self.assertEqual(d.dep_key(),
+                        self.assertEqual(self.tpfilter(d.dep_key()),
                             self.__path_to_key(self.paths["libc_path"]))
                         self.assertEqual(d.action.attrs["path"],
                             self.paths["curses_path"])
@@ -1700,7 +1710,7 @@ file NOHASH group=sys mode=0755 owner=root path={runpath_mod_test_path}
                                     d.dep_vars.sat_set)
                                 self.assertEqual(expected_not_sat,
                                     d.dep_vars.not_sat_set)
-                        elif d.dep_key() == self.__path_to_key(
+                        elif self.tpfilter(d.dep_key()) == self.__path_to_key(
                             self.paths["libc_path"]):
                                 self.assertEqual(
                                     d.action.attrs["path"],
@@ -1739,7 +1749,8 @@ file NOHASH group=sys mode=0755 owner=root path={runpath_mod_test_path}
                 self.assertEqual(expected_sat, d.dep_vars.sat_set)
                 self.assertEqual(expected_not_sat, d.dep_vars.not_sat_set)
                 self.assertEqual(d.base_names[0], "libc.so.1")
-                self.assertEqual(set(d.run_paths), set(["lib", "usr/lib"]))
+                self.assertEqual(self.glfilter(set(d.run_paths)),
+                    set(["lib", "usr/lib"]))
 
                 # Check that internal dependencies are as expected.
                 ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
@@ -1765,7 +1776,7 @@ file NOHASH group=sys mode=0755 owner=root path={runpath_mod_test_path}
                             self.paths["ksh_path"]):
                                 self.assertEqual(d.action.attrs["path"],
                                     self.paths["script_path"])
-                        elif d.dep_key() == self.__path_to_key(
+                        elif self.tpfilter(d.dep_key()) == self.__path_to_key(
                             self.paths["libc_path"]):
                                 self.assertEqual(d.action.attrs["path"],
                                     self.paths["ksh_path"])
@@ -1803,7 +1814,7 @@ file NOHASH group=sys mode=0755 owner=root path={runpath_mod_test_path}
                                     d.dep_vars.sat_set)
                                 self.assertEqual(expected_not_sat,
                                     d.dep_vars.not_sat_set)
-                        elif d.dep_key() == self.__path_to_key(
+                        elif self.tpfilter(d.dep_key()) == self.__path_to_key(
                             self.paths["libc_path"]):
                                 self.assertEqual(d.action.attrs["path"],
                                     self.paths["ksh_path"])
@@ -1847,7 +1858,8 @@ file NOHASH group=sys mode=0755 owner=root path={runpath_mod_test_path}
                 self.assertEqualDiff(expected_not_sat, d.dep_vars.not_sat_set)
 
                 self.assertEqual(d.base_names[0], "libc.so.1")
-                self.assertEqual(set(d.run_paths), set(["lib", "usr/lib"]))
+                self.assertEqual(self.glfilter(set(d.run_paths)),
+                    set(["lib", "usr/lib"]))
 
                 # Check that internal dependencies are as expected.
                 ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
@@ -1876,7 +1888,7 @@ file NOHASH group=sys mode=0755 owner=root path={runpath_mod_test_path}
                             self.paths["ksh_path"]):
                                 self.assertEqual(d.action.attrs["path"],
                                     self.paths["script_path"])
-                        elif d.dep_key() == self.__path_to_key(
+                        elif self.tpfilter(d.dep_key()) == self.__path_to_key(
                             self.paths["libc_path"]):
                                 self.assertEqual(d.action.attrs["path"],
                                     self.paths["ksh_path"])


### PR DESCRIPTION
Our newer gcc packages insert /usr/gcc/<ver>/lib into the runpath of built objects. This upsets several pkg5 tests which check the runpath of build objects and whether the elf module can properly detect them. The approach I've taken here is to install filters which remove the gcc-specific paths from the sets before they are compared for equality.

With these changes, the test-suite passes with gcc8.