### PR TITLE
Support on-demand VNICs

### DIFF
--- a/src/brand/poststate
+++ b/src/brand/poststate
@@ -22,6 +22,7 @@
 
 #
 # Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 #
 
 . /usr/lib/brand/ipkg/common.ksh
@@ -48,8 +49,8 @@ state=$3
 cmd=$4
 ALTROOT=$5
 
-# If we're not halting the zone, then just return.
-if [ $cmd -eq 4 ]; then
+case $cmd in
+    4)		# Halting
 	is_brand_labeled
 	if (( $? == 0 )); then
 		# Leave the active dataset mounted after halting (this might be
@@ -60,6 +61,8 @@ if [ $cmd -eq 4 ]; then
 		zoneroot="$ZONEPATH/root"
 		umount $zoneroot || printf "$f_zfs_unmount" "$zoneroot"
 	fi
-fi
+	unconfig_network
+	;;
+esac
 
 exit $ZONE_SUBPROC_OK

--- a/src/brand/prestate
+++ b/src/brand/prestate
@@ -48,11 +48,17 @@ state=$3
 cmd=$4
 ALTROOT=$5
 
-# If we're not readying the zone, then just return.
-if [ $cmd -eq 0 ]; then
+case $cmd in
+    0)
+	# Going to ready state
 	# Mount active dataset on the root.
 	mount_active_ds
 	config_network
-fi
+	;;
+
+    1)
+	# Pre-boot
+	;;
+esac
 
 exit $ZONE_SUBPROC_OK

--- a/src/brand/sparse/poststate
+++ b/src/brand/sparse/poststate
@@ -13,7 +13,7 @@
 #
 # }}}
 
-# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 
 . /usr/lib/brand/sparse/common.ksh
 
@@ -37,6 +37,7 @@ case $cmd in
 	# Re-mount overlays to support patching while zone is down
 	find_active_ds
 	mount_overlays
+	unconfig_network
 	;;
 esac
 


### PR DESCRIPTION
Most of the work to support on-demand VNICs for zones is already in OmniOS from the lx port. This hooks up the missing bits. A small update is also required in illumos-omnios.

See https://gist.github.com/citrus-it/767a42755825d9dde6d0e8dfb331791f