### PR TITLE
Make pkg/mirror work on OmniOS, and be more configurable

### DIFF
--- a/src/svc/pkg-depot.xml
+++ b/src/svc/pkg-depot.xml
@@ -91,7 +91,7 @@
 		<exec_method
 			type='method'
 			name='start'
-			exec='/lib/svc/method/svc-pkg-depot start'
+			exec='/lib/svc/method/svc-pkg-depot %m'
 			timeout_seconds='60'>
 			<method_context>
 				<method_credential user='pkg5srv'
@@ -103,7 +103,7 @@
 		<exec_method
 			type='method'
 			name='stop'
-			exec='/lib/svc/method/svc-pkg-depot stop'
+			exec='/lib/svc/method/svc-pkg-depot %m'
 			timeout_seconds='60'>
 			<method_context>
 				<method_credential user='pkg5srv'
@@ -115,7 +115,7 @@
 		<exec_method
 			type='method'
 			name='refresh'
-			exec='/lib/svc/method/svc-pkg-depot refresh'
+			exec='/lib/svc/method/svc-pkg-depot %m'
 			timeout_seconds='60'>
 			<method_context>
 				<method_credential user='pkg5srv'

--- a/src/svc/pkg-mirror.xml
+++ b/src/svc/pkg-mirror.xml
@@ -19,7 +19,9 @@
 
 	CDDL HEADER END
 
-	Copyright (c) 2013, 2014, Oracle and/or its affiliates.  All rights reserved.
+	Copyright (c) 2013, 2014, Oracle and/or its affiliates.
+	All rights reserved.
+	Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 
 	NOTE:  This service manifest is not editable; its contents will
 	be overwritten by package or patch operations, including
@@ -35,6 +37,8 @@
 	name='application/pkg/mirror'
 	type='service'
 	version='1'>
+
+	<create_default_instance enabled="false" />
 
         <!--
           Wait for network interfaces to be initialized.
@@ -71,9 +75,8 @@
         </dependency>
 
 	<!--
-	  Wait until the service which creates the
-	  <rpool>/VARSHARE/pkg/repositories container dataset to come
-	  online.
+	  Wait until the service which creates the default parent dataset to
+	  come online.
 	-->
 	<dependency name='varshare-repositories'
 	    grouping='require_all'
@@ -86,7 +89,7 @@
         <exec_method
                 type='method'
                 name='start'
-                exec='/lib/svc/method/svc-pkg-mirror start'
+                exec='/lib/svc/method/svc-pkg-mirror %m'
                 timeout_seconds='60'>
 		<method_context>
 			<method_credential
@@ -97,7 +100,7 @@
         <exec_method
                 type='method'
                 name='stop'
-                exec='/lib/svc/method/svc-pkg-mirror stop'
+                exec='/lib/svc/method/svc-pkg-mirror %m'
                 timeout_seconds='60'>
 		<method_context>
 			<method_credential
@@ -111,14 +114,13 @@
 	<exec_method
                 type='method'
                 name='refresh'
-                exec='/lib/svc/method/svc-pkg-mirror refresh'
+                exec='/lib/svc/method/svc-pkg-mirror %m'
                 timeout_seconds='0'>
 		<method_context>
 			<method_credential
 				user='pkg5srv' group='pkg5srv' />
 		</method_context>
 	</exec_method>
-
 
 	<property_group name='general' type='framework'>
         	<propval name='action_authorization' type='astring'
@@ -130,36 +132,28 @@
         </property_group>
 
 	<property_group name='startd' type='framework'>
-		<propval name='duration' type='astring'
-			value='transient' />
+		<propval name='duration' type='astring' value='transient' />
 	</property_group>
 
         <property_group name='config' type='application'>
                 <stability value='Evolving' />
 
-		<!-- The local repository we pkgrecv to. By default,
-		if we the parent directory is at the top-level of a
-		zfs dataset, we attempt to create a new dataset for the
-		repository. For this to happen, 'pkg5srv' must have
-		appropriate zfs delegations on that dataset, eg.
-
-		# zfs allow pkg5srv create,mount,snapshot <dataset>
-
-		In the default configuration, a dataset is created by
-		svc:/application/pkg/varshare-repositories which we
-		have a dependency on.
-		-->
+		<!-- The local repository directory to which we pkgrecv.
+		This property can be an absolute or relative path. If
+		relative then it is created under the dataset created by
+		svc:/application/pkg/repositories-setup (on which this
+		service has a dependency).  -->
                 <propval name='repository' type='astring'
-			value='/var/share/pkg/repositories/openindiana' />
+		    value='omnios' />
 
-                <!-- A partial crontab(1) entry defining how often we
+                <!--A partial crontab(1) entry defining how often we
 		update the repository. We allow the special value
 		'random' in the 3rd (day of the month) field in order
 		to even the load on busy repository servers. This gets
 		replaced when the service is first started with a random
 		day in the range 1-28. -->
                 <propval name='crontab_period' type='astring'
-			value='30 2 random * *' />
+			value='30 2 * * *' />
 
 		<!-- The reference image we use to pull publisher,
 		origin, proxy and ssl key/cert information from -->
@@ -170,7 +164,7 @@
 		'config/ref_image' which we receive from.
 		 -->
 		<propval name='publishers' type='astring'
-			value='openindiana.org,hipster-encumbered' />
+			value='omnios' />
 
 		<!-- The cache_dir used for the -c option to pkgrecv(1M)
 		-->
@@ -186,37 +180,6 @@
         	        value='solaris.smf.manage.pkg-mirror' />
         </property_group>
 
-        <!-- To work around an SMF bug, we create a default instance
-	containing the 'config' property group, specifiying the
-	authorizations we need to allow clients to modify values in it.
-	User-created instances should create this pg with the same
-	'value_authorization' property.
-
-	Without setting these authorizations, user-created instances
-	that use the "random" keyword in the crontab_period will never
-	have that value persistently replaced, and so each time the
-	service starts, the cron job will fire on a different date.
-	-->
-        <instance name="default" enabled="false">
-                <property_group name='config' type='application'>
-                <stability value='Evolving' />
-                <propval name='repository' type='astring'
-			value='/var/share/pkg/repositories/openindiana' />
-                <propval name='crontab_period' type='astring'
-			value='30 2 * * *' />
-                <propval name='ref_image' type='astring' value='/' />
-		<propval name='publishers' type='astring'
-			value='openindiana.org,hipster-encumbered' />
-                <propval name='cache_dir' type='astring'
-                        value='/var/cache/pkg/mirror' />
-                <propval name='debug' type='boolean' value='false' />
-
-		<propval
-                	name='value_authorization'
-	                type='astring'
-        	        value='solaris.smf.manage.pkg-mirror' />
-                </property_group>
-        </instance>
 	<stability value='Evolving' />
 
         <template>

--- a/src/svc/pkg-repositories-setup.xml
+++ b/src/svc/pkg-repositories-setup.xml
@@ -20,6 +20,7 @@
 	CDDL HEADER END
 
 	Copyright (c) 2013, Oracle and/or its affiliates.  All rights reserved.
+	Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 
 	NOTE:  This service manifest is not editable; its contents will
 	be overwritten by package or patch operations, including
@@ -36,17 +37,13 @@
 	type='service'
 	version='1'>
 
-	<!-- This SMF service creates a dataset
-	 <rpool>/VARSHARE/pkg/repositories and assigns zfs delegations
-	to allow 'pkg5srv' to create,mount and snapshot datasets within
-	<rpool>/VARSHARE/pkg
+	<!--
+		This SMF service creates a dataset and assigns zfs delegations
+		to allow 'pkg5srv' to create, mount and snapshot datasets within
 	-->
 
 	<create_default_instance enabled='false' />
 
-        <!--
-          Wait for all local filesystems to be mounted.
-        -->
         <dependency name='filesystem-local'
             grouping='require_all'
             restart_on='none'
@@ -58,7 +55,7 @@
         <exec_method
                 type='method'
                 name='start'
-                exec='/lib/svc/method/svc-pkg-repositories-setup start'
+                exec='/lib/svc/method/svc-pkg-repositories-setup %m'
                 timeout_seconds='60'>
 	</exec_method>
 
@@ -66,20 +63,27 @@
                 type='method'
                 name='stop'
                 exec=':true'
-                timeout_seconds='60'>		
+                timeout_seconds='60'>
 	</exec_method>
 
 	<property_group name='startd' type='framework'>
-		<propval name='duration' type='astring'
-			value='transient' />
+		<propval name='duration' type='astring' value='transient' />
 	</property_group>
 
-        
+	<property_group name='config' type='application'>
+		<propval name='dataset' type='astring'
+		    value='pkg-repositories'/>
+		<propval name='mountpoint' type='astring'
+		    value='/var/share/pkg/repositories'/>
+	</property_group>
+
 	<stability value='Evolving' />
 
         <template>
                 <common_name>
-                    <loctext xml:lang='C'>IPS rpool/VARSHARE/pkg creation</loctext>
+                    <loctext xml:lang='C'>
+			IPS dataset creation
+		    </loctext>
                 </common_name>
         </template>
 

--- a/src/svc/pkg-system-repository.xml
+++ b/src/svc/pkg-system-repository.xml
@@ -78,7 +78,7 @@
 		<exec_method
 			type='method'
 			name='start'
-			exec='/lib/svc/method/svc-pkg-sysrepo start'
+			exec='/lib/svc/method/svc-pkg-sysrepo %m'
 			timeout_seconds='60'>
 			<method_context>
 				<method_credential user='pkg5srv'
@@ -91,7 +91,7 @@
 		<exec_method
 			type='method'
 			name='stop'
-			exec='/lib/svc/method/svc-pkg-sysrepo stop'
+			exec='/lib/svc/method/svc-pkg-sysrepo %m'
 			timeout_seconds='60' >
 			<method_context>
 				<method_credential user='pkg5srv'
@@ -104,7 +104,7 @@
 		<exec_method
 			type='method'
 			name='refresh'
-			exec='/lib/svc/method/svc-pkg-sysrepo refresh'
+			exec='/lib/svc/method/svc-pkg-sysrepo %m'
 			timeout_seconds='60' >
 			<method_context>
              			<method_credential user='pkg5srv'

--- a/src/svc/pkg5_include.sh
+++ b/src/svc/pkg5_include.sh
@@ -45,19 +45,25 @@ SVCPROP=/usr/bin/svcprop
 #
 function check_failure {
 
-	typeset RESULT=$1
-	typeset ERR_MSG=$2
-	typeset FMRI=$3
-	typeset MODE=$4
+	typeset RESULT="$1"
+	typeset ERR_MSG="$2"
+	typeset FMRI="$3"
+	typeset MODE="$4"
 
 	if [ $RESULT -ne 0 ] ; then
 		echo "Error: $ERR_MSG"
-		if [ "$MODE" = "degrade" ] ; then
+		case $MODE in
+		    degrade)
 			echo "Moving service $FMRI to maintenance mode."
 			$SVCADM mark maintenance $FMRI
-		elif [ "$MODE" = "exit" ] ; then
+			;;
+		    exit)
 			exit 1
-		fi
+			;;
+		    fatal)
+			exit $SMF_EXIT_ERR_FATAL
+			;;
+		esac
 	fi
 	return $RESULT
 }

--- a/src/svc/svc-pkg-mirror
+++ b/src/svc/svc-pkg-mirror
@@ -20,6 +20,7 @@
 # CDDL HEADER END
 #
 # Copyright (c) 2013, 2015, Oracle and/or its affiliates.  All rights reserved.
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 #
 
 #
@@ -75,6 +76,10 @@ WC=/usr/bin/wc
 ZFS=/usr/sbin/zfs
 
 SVCNAME=svc:/application/pkg/mirror
+RSVCNAME=svc:/application/pkg/repositories-setup
+
+reporoot="`svcprop -p config/mountpoint $RSVCNAME`"
+[ -n "$reporoot" ] || reporoot=/var/share/pkg/repositories
 
 #
 # Since we deal with '*' values in crontab fields, we never want
@@ -100,7 +105,7 @@ function check_duplicate_repos {
 	# if the unique list of repositories is not the same as the
 	# list of repositories, then we have duplicates.
 	#
-	if [ "$ALL_REPOS" != "$REPOS" ]; then		
+	if [ "$ALL_REPOS" != "$REPOS" ]; then
 		return 1
 	fi
 	return 0
@@ -139,7 +144,7 @@ function add_date_jitter {
 		}'
 
 	check_failure $? "invalid value for config/crontab_period." \
-	    $SMF_FMRI exit
+	    $SMF_FMRI fatal
 
 	RAND=$(( ($RANDOM % 27) + 1 ))
 	new_schedule=$(echo "$schedule" | $SED -e "s/random/$RAND/1")
@@ -167,9 +172,10 @@ function smf_schedule_updates {
 
 	check_duplicate_repos
 	check_failure $? "Two or more instances of $SVCNAME contain the
-same 'config/repository' value, which is not supported." $SMF_FMRI exit
+same 'config/repository' value, which is not supported." $SMF_FMRI fatal
 	typeset -f schedule=$(add_date_jitter | $SED -e 's/\\//g')
 	typeset repo=$($SVCPROP -p config/repository $SMF_FMRI)
+	[[ "$repo" == /* ]] || repo="$reporoot/$repo"
 
 	SAVED_IFS="$IFS"
 	IFS=,
@@ -187,22 +193,18 @@ same 'config/repository' value, which is not supported." $SMF_FMRI exit
 			#
 			DS="$special/$repo_base"
 
-			#
-			# We set canmount=noauto so that multiple bootable
-			# rpools can coexist on the same system.
-			#
-			$ZFS create -o canmount=noauto "$DS"
+			$ZFS create "$DS"
 			check_failure $? \
 			    "unable to create zfs dataset $DS" \
-			    $SMF_FMRI degrade
+			    $SMF_FMRI fatal
 			$ZFS mount "$DS"
 			check_failure $? \
 			    "unable to mount zfs dataset $DS" \
-			    $SMF_FMRI degrade
+			    $SMF_FMRI fatal
 		fi
 		$PKGREPO create "$repo"
 		check_failure $? "unable to create repository" \
-		    $SMF_FMRI degrade
+		    $SMF_FMRI fatal
 	fi
 	set_default_publisher "$repo" ${publishers[0]}
 	add_cronjob $SMF_FMRI "$schedule" \
@@ -242,7 +244,7 @@ function set_default_publisher {
 # 'pkgrecv_from_origin' for each publisher configured in the SMF
 # instance.
 #
-# Usage: 
+# Usage:
 #     update_repository <smf fmri>
 #
 function update_repository {
@@ -253,18 +255,20 @@ function update_repository {
 
 	if [ -f $lockfile ]; then
 		pid=$(<$lockfile)
-		check_failure 1 "A mirror operation was already running
+		echo "A mirror operation was already running
  under process $pid when the cron job fired. Remove $lockfile to
  override, or check the SMF property 'config/crontab_period' to ensure
- cron schedules don't overlap." $SMF_FMRI degrade
+ cron schedules don't overlap."
+		echo $SMF_EXIT_FATAL
 		return 1
 	fi
 	# write our pid into the lock file
 	echo $$ > $lockfile
-	check_failure $? "unable to create lockfile" $SMF_FMRI degrade
+	check_failure $? "unable to create lockfile" $SMF_FMRI fatal
 
-	typeset repo=$($SVCPROP -p config/repository $SMF_FMRI \
-	    | $SED -e 's/\\//g')
+	typeset repo=$($SVCPROP -p config/repository $SMF_FMRI)
+	[[ "$repo" == /* ]] || repo="$reporoot/$repo"
+	repo=$(echo $repo | $SED -e 's/\\//g')
 	typeset cachedir=$($SVCPROP -p config/cache_dir $SMF_FMRI \
 	    | $SED -e 's/\\//g')
 	typeset ref_image=$($SVCPROP -p config/ref_image $SMF_FMRI\
@@ -363,7 +367,7 @@ configured for publisher $pub"
 		    "$https_proxy" "$clone" "$pub"
 		check_failure $? \
 		    "unable to update repository $repo" $SMF_FMRI \
-		    degrade
+		    fatal
 		if [ $? -ne 0 ]; then
 			$RM $lockfile
 			return 1
@@ -427,7 +431,7 @@ function pkgrecv_from_origin {
 		key="--key $key"
 		cert="--cert $cert"
 	fi
-	
+
 	set -f
 	if [ -n "$clone" ]; then
 		cmd="$PKGRECV -s $origin -d "$repo" -p $publisher \
@@ -498,7 +502,7 @@ case "$1" in
 #	packages that were received during that run of the cron job.
 #
 # /var/log/pkg/mirror/mirror.<instance>.run.<pid>
-# 	This is a temporary log file, which should contain very little
+#	This is a temporary log file, which should contain very little
 #       output - it exists to capture all other output from the service
 #	If 'config/debug' is set, then this file will also include the
 #       full pkgrecv(1) command that is executed.

--- a/src/svc/svc-pkg-repositories-setup
+++ b/src/svc/svc-pkg-repositories-setup
@@ -20,6 +20,7 @@
 # CDDL HEADER END
 #
 # Copyright (c) 2013, 2016, Oracle and/or its affiliates.  All rights reserved.
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 #
 
 # Load SMF constants and functions
@@ -30,73 +31,54 @@
 CHOWN=/usr/bin/chown
 ZFS=/usr/sbin/zfs
 
-result=$SMF_EXIT_ERR_FATAL
+dataset="`svcprop -p config/dataset $SMF_FMRI`"
+[ -n "$dataset" ] || dataset=pkg-repositories
+
+mp="`svcprop -p config/mountpoint $SMF_FMRI`"
+[ -n "$mp" ] || mp=/var/share/pkg/repositories
 
 case "$1" in
 'start')
-	# check if we already have a mounted /var/share/pkg/repositories
-	readmnttab /var/share/pkg/repositories < /etc/mnttab
-	if [ "$fstype" = zfs ] ; then
-		exit $SMF_EXIT_OK
-	else
-		readmnttab / < /etc/mnttab
-		if [ "$fstype" = zfs ] ; then
-			#
-			# $special gets set by readmnttab in
-			# /lib/svc/share/fs_include.sh
-			#
-			be=$special
-			#rpool=$(print $be | cut -d / -f1)			
-			# we use now baseds, as OI does not provide a "fake" rpool for a zone
-			# we need to store our VARSHARE under <zoneroot>/ROOT/VARSHARE
-			baseds=$(/usr/bin/dirname $be)
-		else
-			# we're on a LiveCD, so exit immediately.
-			exit $SMF_EXIT_OK
-		fi
+	# check if we already have a mounted dataset
+	readmnttab $mp < /etc/mnttab
+	[ "$fstype" = zfs ] && exit $SMF_EXIT_OK
 
-		DS="$baseds/VARSHARE/pkg/repositories"
+	# Only continue if the system has a ZFS root
+	readmnttab / < /etc/mnttab
+	[ "$fstype" = zfs ] || exit $SMF_EXIT_OK
 
-		# If the dataset exists, we mount it along with any child
-		# datasets, then exit.
-		$ZFS list "$DS" > /dev/null 2>&1
-		if [ $? -eq 0 ] ; then
-			child_fs_mount=0
-			for child in $($ZFS list -H -r -t filesystem \
-			    -o name "$DS"); do
-				$ZFS mount "$child"
-				child_fs_mount=$(( $child_fs_mount + $? ))
-			done
-			if [ $child_fs_mount -eq 0 ] ; then
-				exit $SMF_EXIT_OK
-			else
-				check_failure 1 \
-				    "Unable to mount child datasets of $DS" \
-				    $SMF_FMRI exit
-			fi
-		fi
+	# readmnttab has populated 'special'
+	be=$special
+	pool=${special%%/*}
 
-		# Otherwise, we need to create the dataset, taking care to set
-		# canmount=noauto, to allow multiple bootable rpools to coexist
-		# on the same system.
-		$ZFS create -p $DS
-		check_failure $? "Unable to create $DS" $SMF_FMRI exit
-
-		for fs in "$baseds/VARSHARE/pkg" \
-		    "$baseds/VARSHARE/pkg/repositories" ; do
-			$ZFS set canmount=noauto $fs
+	# If the dataset exists, mount it along with any child datasets,
+	# then exit.
+	if $ZFS list "$pool/$dataset" >/dev/null 2>&1; then
+		child_fs_mount=0
+		for child in \
+		    `$ZFS list -H -r -t filesystem -o name "$pool/$dataset"`
+		do
+			$ZFS mount "$child"
+			((child_fs_mount += $?))
 		done
-
-		$ZFS allow pkg5srv create,mount,canmount,snapshot "$DS"
-		check_failure $? \
-		    "Unable to delegate ZFS permissions on $DS" \
-		    $SMF_FMRI exit
-
-		$CHOWN pkg5srv:pkg5srv /var/share/pkg/repositories
-		check_failure $? \
-		    "Unable to chown /var/share/pkg/repositories" \
-		    $SMF_FMRI exit
+		[ "$child_fs_mount" -eq 0 ] && exit $SMF_EXIT_OK
+		echo "Unable to mount child datasets of $pool/$dataset"
+		exit $SMF_EXIT_ERR_FATAL
 	fi
+
+	# Otherwise, create the dataset, and delegate permissions to the user.
+	$ZFS create -o mountpoint="$mp" "$pool/$dataset"
+	check_failure $? "Unable to create $pool/$dataset" $SMF_FMRI fatal
+
+	$ZFS allow pkg5srv create,mount,canmount,snapshot "$pool/$dataset"
+	check_failure $? \
+	    "Unable to delegate ZFS permissions on $pool/$dataset" \
+	    $SMF_FMRI fatal
+
+	$CHOWN pkg5srv:pkg5srv "$mp"
+	check_failure $? \
+	    "Unable to chown $mp" \
+	    $SMF_FMRI fatal
 	;;
 esac
 


### PR DESCRIPTION
We have shipped the `pkg/mirror` service with each release but it does not work out of the box, having things that only work on Solaris and others that are tuned for OpenIndiana.

These changes fix that and make it more configurable.

By default, just `svcadm enable -r pkg/mirror` will create some ZFS datasets, set permissions and delegate ZFS privileges to the pkg5srv user, and add a cron entry for that user to refresh the mirror each night.

```
bloody% zfs list
NAME                                USED  AVAIL  REFER  MOUNTPOINT
...
rpool/pkg-repositories              309M   241G   176K  /var/share/pkg/repositories
rpool/pkg-repositories/omnios       308M   241G   308M  /var/share/pkg/repositories/omnios
...
```

```
% pfexec crontab -l pkg5srv
30 2 * * * /usr/sbin/svcadm refresh svc:/application/pkg/mirror:default
```

```
% svcprop -p config pkg/repositories-setup
config/dataset astring pkg-repositories
config/mountpoint astring /var/share/pkg/repositories
```

```
% svcprop -p config pkg/mirror
config/cache_dir astring /var/cache/pkg/mirror
config/ref_image astring /
config/crontab_period astring 30\ 2\ *\ *\ *
config/publishers astring omnios
config/repository astring omnios
```