### PR TITLE
Use persistence for on-demand VNICs

### DIFF
--- a/src/brand/common.ksh
+++ b/src/brand/common.ksh
@@ -572,7 +572,7 @@ config_network() {
 		opt=
 		[ "$mac" != "-" ] && opt+=" -m $mac"
 		[ "$vlan" != "-" -a "$vlan" != "0" ] && opt+=" -v $vlan"
-		if ! dladm create-vnic -t -l $global $opt $nic; then
+		if ! dladm create-vnic -l $global $opt $nic; then
 			echo "Could not create VNIC $nic/$global"
 			exit $ZONE_SUBPROC_FATAL
 		fi


### PR DESCRIPTION
While temporary/transient links are make sense here due to their short-lived
nature, it is not possible to configure persistent addressing information
on these links within the zone. Revert to them being persistent and accept
that events like a system crash could leave VNICs hanging around. The zone
startup code will just re-use them when the zone boots.