### PR TITLE
Support auto-be-name time: prefix for current date/time

### DIFF
--- a/src/man/pkg.1
+++ b/src/man/pkg.1
@@ -1,7 +1,7 @@
 '\" te
 .\" Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
-.\" Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
-.TH pkg 1 "10 Sep 2018" "SunOS 5.11" "User Commands"
+.\" Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+.TH pkg 1 "28 Feb 2019" "illumos" "User Commands"
 .SH NAME
 pkg \- Image Packaging System retrieval client
 .SH SYNOPSIS
@@ -3218,7 +3218,7 @@ this property. The template can contain the following tokens; see the
 .ad
 .sp .6
 .RS 4n
-The date of the update being installed - \fIYYYY.MM.DD\R
+The publication date of the update being installed - \fIYYYY.MM.DD\R
 .RE
 
 .sp
@@ -3229,7 +3229,7 @@ The date of the update being installed - \fIYYYY.MM.DD\R
 .ad
 .sp .6
 .RS 4n
-The date of the update being installed - \fIYYYYMMDD\R
+The publication date of the update being installed - \fIYYYYMMDD\R
 .RE
 
 .sp
@@ -3241,6 +3241,20 @@ The date of the update being installed - \fIYYYYMMDD\R
 .sp .6
 .RS 4n
 The release being installed, without the leading \fIr\fR - e.g. \fB151026c\fR
+.RE
+
+.sp
+.ne 2
+.mk
+.na
+\fBtime:<format>\fR
+.ad
+.sp .6
+.RS 4n
+The current date and time in the format specified. \fIformat\fR is a
+\fBstrftime\fR(3C)-compatible string such as \fBomnios-%Y.%m.%d\fR.
+It is not advised to use hyphens for separating components as the trailing
+component may be confused with a boot environment revision number.
 .RE
 
 .sp
@@ -4236,8 +4250,20 @@ $ \fBpkg set-property auto-be-name omnios_r%r_%D\fR
 .sp
 
 .LP
+To use the current date and time, use the \fItime:\fR prefix and a format
+string:
+.sp
+.in +2
+.nf
+$ \fBpkg set-property auto-be-name time:omnios_%Y%m%d\fR
+.fi
+.in -2
+.sp
+
+.LP
 For bloody releases, the release name does not change and so the \fI%r\fR
-token is not available:
+token is not available. The %D token can be used to include the release date
+in the BE name:
 .sp
 .in +2
 .nf

--- a/src/modules/client/api.py
+++ b/src/modules/client/api.py
@@ -22,6 +22,7 @@
 
 #
 # Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 #
 
 """This module provides the supported, documented interface for clients to
@@ -136,6 +137,8 @@ RESULT_FAILED_ACTUATOR = history.RESULT_FAILED_ACTUATOR
 RESULT_FAILED_OUTOFMEMORY = history.RESULT_FAILED_OUTOFMEMORY
 RESULT_CONFLICTING_ACTIONS = history.RESULT_CONFLICTING_ACTIONS
 RESULT_FAILED_UNKNOWN = history.RESULT_FAILED_UNKNOWN
+
+AUTO_BE_NAME_TIME_PREFIX = "time:"
 
 # Globals.
 logger = global_settings.logger
@@ -703,41 +706,52 @@ in the environment or by setting simulate_cmdpath in DebugValues.""")
                 if not be_template or len(be_template) == 0:
                         return
 
-                release = date = None
-                # Check to see if release/name is being updated
-                for src, dest in self._img.imageplan.plan_desc:
-                        if not dest or dest.get_name() != 'release/name':
-                                continue
-                        # It is, extract attributes
-                        for a in self._img.imageplan.pd.update_actions:
-                                if not isinstance(a.dst,
-                                    actions.attribute.AttributeAction):
+                if be_template.startswith(AUTO_BE_NAME_TIME_PREFIX):
+                        try:
+                                be_template = time.strftime(
+                                    be_template[len(AUTO_BE_NAME_TIME_PREFIX):])
+                        except:
+                                return
+                else:
+                        release = date = None
+                        # Check to see if release/name is being updated
+                        for src, dest in self._img.imageplan.plan_desc:
+                                if (not dest or
+                                    dest.get_name() != 'release/name'):
                                         continue
-                                name = a.dst.attrs['name']
-                                if name == 'ooce.release':
-                                        release = a.dst.attrs['value']
-                                elif name == 'ooce.release.build':
-                                        date = a.dst.attrs['value']
-                                if release and date:
-                                        break
-                        break
+                                # It is, extract attributes
+                                for a in self._img.imageplan.pd.update_actions:
+                                        if not isinstance(a.dst,
+                                            actions.attribute.AttributeAction):
+                                                continue
+                                        name = a.dst.attrs['name']
+                                        if name == 'ooce.release':
+                                                release = a.dst.attrs['value']
+                                        elif name == 'ooce.release.build':
+                                                date = a.dst.attrs['value']
+                                        if release and date:
+                                                break
+                                break
 
-                if not release and not date:
-                        # No variables changed in this update
-                        return
+                        if not release and not date:
+                                # No variables changed in this update
+                                return
 
-                if '%r' in be_template and not release:
+                        if '%r' in be_template and not release:
+                                return
+                        if '%d' in be_template and not date:
+                                return
+                        if '%D' in be_template and not date:
+                                return
+                        if release:
+                                be_template = be_template.replace('%r', release)
+                        if date:
+                                be_template = be_template.replace('%d', date)
+                                be_template = be_template.replace('%D',
+                                    date.replace('.', ''))
+
+                if not be_template or len(be_template) == 0:
                         return
-                if '%d' in be_template and not date:
-                        return
-                if '%D' in be_template and not date:
-                        return
-                if release:
-                        be_template = be_template.replace('%r', release)
-                if date:
-                        be_template = be_template.replace('%d', date)
-                        be_template = be_template.replace('%D',
-                            date.replace('.', ''))
 
                 be = bootenv.BootEnv(self._img)
                 self.__be_name = be.get_new_be_name(new_bename=be_template)


### PR DESCRIPTION
Based on part of https://github.com/OpenIndiana/pkg5/pull/58

```
% pfexec pkg set-property auto-be-name time:%Y.%m.%d

% pfexec pkg update --require-new-be bind
            Packages to update:   1
       Create boot environment: Yes
Create backup boot environment:  No

DOWNLOAD                                PKGS         FILES    XFER (MB)   SPEED
Completed                                1/1         15/15      1.7/1.7      --

PHASE                                          ITEMS
Removing old actions                             8/8
Installing new actions                           8/8
Updating modified actions                      23/23
Updating package state database                 Done
Updating package cache                           1/1
Updating image state                            Done
Creating fast lookup database                   Done
Reading search index                            Done
Updating search index                            1/1

A clone of 20190301 exists and has been updated and activated.
On the next boot the Boot Environment 2019.03.05 will be
mounted on '/'.  Reboot when ready to switch to this updated BE.

*** Reboot required ***
New BE: 2019.03.05
```