### PR TITLE
Fix KeyError traceback on invalid action during pkgsend

### DIFF
--- a/src/modules/actions/_common.c
+++ b/src/modules/actions/_common.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
  */
 
 /*
@@ -38,16 +39,23 @@ set_invalid_action_error(const char *name, PyObject *action,
 	PyObject *exc = NULL;
 	PyObject *val = NULL;
 	PyObject *pkg_actions = NULL;
+	PyObject *sys = NULL;
+	PyObject *sys_modules = NULL;
 
-	/*
-	 * TODO: unknown issue: importing pkg.actions can fail in Python 3, see
-	 * one test case in api/t_action.py`test_action_errors.
-	 */
-	if ((pkg_actions = PyImport_ImportModule("pkg.actions")) == NULL) {
+	if ((sys = PyImport_ImportModule("sys")) == NULL)
+		return;
+
+	if ((sys_modules = PyObject_GetAttrString(sys, "modules")) == NULL)
+		return;
+
+	if ((pkg_actions = PyDict_GetItemString(sys_modules, "pkg.actions"))
+	    == NULL) {
 		/* No exception is set */
-		PyErr_SetString(PyExc_KeyError, "pkg.actions");
+		PyErr_SetString(PyExc_KeyError, "siae.pkg.actions");
+		Py_DECREF(sys_modules);
 		return;
 	}
+	Py_DECREF(sys_modules);
 
 	/*
 	 * Obtain a reference to the action exception type so that SetObject can
@@ -300,7 +308,7 @@ moduleinit(void)
 
 	if ((pkg_actions = PyImport_ImportModule("pkg.actions")) == NULL) {
 		/* No exception is set */
-		PyErr_SetString(PyExc_KeyError, "pkg.actions");
+		PyErr_SetString(PyExc_KeyError, "_common.pkg.actions");
 		return (NULL);
 	}
 


### PR DESCRIPTION
Before:

```
Traceback (most recent call last):
  File "/usr/bin/pkgsend", line 858, in <module>
    __ret = main_func()
  File "/usr/bin/pkgsend", line 812, in main_func
    visitors=visitors)
  File "/usr/bin/pkgsend", line 694, in trans_generate
    use_default_owner=use_default_owner):
  File "/usr/bin/pkgsend", line 588, in gen_actions
    for action in bundle:
  File "/usr/lib/python3.5/vendor-packages/pkg/bundle/DirectoryBundle.py", line 79, in __iter__
    act = self.action(*data)
  File "/usr/lib/python3.5/vendor-packages/pkg/bundle/DirectoryBundle.py", line 128, in action
    timestamp=timestamp)
  File "/usr/lib/python3.5/vendor-packages/pkg/actions/file.py", line 962, in __init__
    _common._file_init(self, data, **attrs)
KeyError: 'pkg.actions'


pkgsend: This is an internal error in pkg(5) version bd324b341.  Please log a
Service Request about this issue including the information above and this
message.
```

After:

```
pkgsend: invalid action, 'file group=bin mode=0644 owner=root path=\udcc3\udc84foo.go pkg.size=192 timestamp=20190314T194337Z': Empty or invalid path attribute
```

test suite baseline matches.