### PR TITLE
Traceback during pkglint resolution of dependencies

### DIFF
--- a/src/modules/lint/engine.py
+++ b/src/modules/lint/engine.py
@@ -71,7 +71,7 @@ class LintEngineCache():
                 # release is a build number, eg. 150
                 # version_pattern used by the engine is a regexp, intended
                 # to be used when searching for images, combined with the
-                # release - eg. "*,5.11-0."
+                # release - eg. "*,5.11-151"
                 #
                 self.version_pattern = version_pattern
                 self.release = release
@@ -272,8 +272,8 @@ class LintEngine(object):
 
         'version.pattern' A version pattern, used when specifying a build number
         to lint against (-b). If not specified in the rcfile, this pattern is
-        "*,5.11-0.", matching all components of the '5.11' build, with a branch
-        prefix of '0.'
+        "*,5.11-151", matching all components of the '5.11' build, with a branch
+        prefix of '151'
 
         'info_classification_path' A path the file used to check the values
         of info.classification attributes in manifests.
@@ -303,7 +303,7 @@ class LintEngine(object):
                 self.pattern = None
                 self.release = None
                 # a prefix for the pattern used to search for given releases
-                self.version_pattern = "*,5.11-0."
+                self.version_pattern = "*,5.11-151"
 
                 # lists of checker functions and excluded checker functions
                 self.checkers = []
@@ -1262,6 +1262,11 @@ def lint_fmri_successor(new, old, ignore_pubs=True, ignore_timestamps=True):
                 if new.version.release > old.version.release:
                         return True
                 if new.version.release < old.version.release:
+                        return False
+
+                if new.version.branch and not old.version.branch:
+                        return True
+                if old.version.branch and not new.version.branch:
                         return False
 
                 if new.version.branch > old.version.branch:


### PR DESCRIPTION
```
ERROR lint.error                  Checker exception from pkglint.action005 on action depend fmri=pkg:/network/openssh@7.9.1 type=require in pkg:/network/openssh-server@7.9.1,5.11-151029.0: unorderable types: DotSequence() > NoneType()
Traceback (most recent call last):
  File "/usr/lib/python3.5/vendor-packages/pkg/lint/base.py", line 241, in check
    func(action, manifest, engine)
  File "/usr/lib/python3.5/vendor-packages/pkg/lint/pkglint_action.py", line 1335, in dep_obsolete
    ignore_pubs=engine.ignore_pubs):
  File "/usr/lib/python3.5/vendor-packages/pkg/lint/engine.py", line 1267, in lint_fmri_successor
    if new.version.branch > old.version.branch:
TypeError: unorderable types: DotSequence() > NoneType()

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/pkglint", line 329, in <module>
    __ret = main_func()
  File "/usr/bin/pkglint", line 156, in main_func
    lint_engine.execute()
  File "/usr/lib/python3.5/vendor-packages/pkg/lint/engine.py", line 647, in execute
    action_checks)
  File "/usr/lib/python3.5/vendor-packages/pkg/lint/engine.py", line 971, in _check_manifest
    action_checks)
  File "/usr/lib/python3.5/vendor-packages/pkg/lint/engine.py", line 977, in _check_action
    checker.check(action, manifest, self)
  File "/usr/lib/python3.5/vendor-packages/pkg/lint/base.py", line 266, in check
    engine.debug(traceback.format_exc(err),
  File "/usr/lib/python3.5/traceback.py", line 163, in format_exc
    return "".join(format_exception(*sys.exc_info(), limit=limit, chain=chain))
  File "/usr/lib/python3.5/traceback.py", line 117, in format_exception
    type(value), value, tb, limit=limit).format(chain=chain))
  File "/usr/lib/python3.5/traceback.py", line 474, in __init__
    capture_locals=capture_locals)
  File "/usr/lib/python3.5/traceback.py", line 332, in extract
    if limit >= 0:
TypeError: unorderable types: TypeError() >= int()
pkglint:

This is an internal error in pkg(5) version 848463b4.  Please log a
Service Request about this issue including the information above and this
message.
Error:

This is an internal error in pkg(5) version 848463b4.  Please log a
Service Request about this issue including the information above and this
message.
```