### PR TITLE
Fix optional package installation (ignore version component)

### DIFF
--- a/src/brand/pkgcreatezone
+++ b/src/brand/pkgcreatezone
@@ -256,7 +256,8 @@ if [[ -n $entire_fmri ]]; then
 	    -o fmri,variant.opensolaris.zone $entire_fmri \
 	    | nawk '$2 != "global" { print $1 }' \
 	    | while read pkg; do
-		$PKG list -q $pkg && pkglist="$pkglist $pkg"
+		pkg=${pkg%%@*}
+		$PKG list -q $pkg && pkglist+=" $pkg"
 	done
 else
 	# If no entire was found, then add a small default set of packages.

--- a/src/brand/sparse/pkgcreatezone
+++ b/src/brand/sparse/pkgcreatezone
@@ -154,7 +154,8 @@ pkglist="$entire_fmri"
 # and not constrained to IPS images of type 'full'
 lc_pkg contents -H -a type=optional -o fmri,variant.opensolaris.imagetype \
     $entire_fmri | nawk '$2 != "full" { print $1 }' | while read pkg; do
-        lc_pkg list -q $pkg && pkglist="$pkglist $pkg"
+        pkg=${pkg%%@*}
+        lc_pkg list -q $pkg && pkglist+=" $pkg"
 done
 
 # For packages which have a cross-zone version dependency, ensure that the


### PR DESCRIPTION
Problem reported on r151028 by Peter Tribble.

Our current `openssh` package has a dash revision of 1, this means that the zone installed does not think the package is installed in the GZ.

```
r28% pkg list pkg://omnios/network/openssh-server@7.8,5.11-151028.0
pkg list: no packages matching the following patterns are installed:
  pkg://omnios/network/openssh-server@7.8,5.11-151028.0

r28% pkg list pkg://omnios/network/openssh-server@7.8,5.11-151028
NAME (PUBLISHER)                                  VERSION                    IFO
network/openssh-server                            7.8.1-151028.1             i--
```

Entire specifies a minimum version (7.8 < 7.8.1), but that is not working for the dash-revision component (0 < 1). We can ignore the version component entirely when checking if a package is installed in the GZ.