### PR TITLE
Add support for setting the viona feature mask

### DIFF
--- a/src/brand/bhyve/init
+++ b/src/brand/bhyve/init
@@ -239,9 +239,12 @@ for i, v in disklist.items():
 
 i = 0
 for f in root.findall('./network[@physical]'):
+    mask = f.find("./net-attr[@name='feature_mask']")
+    feature_mask = mask.get('value') if mask is not None else 0
     args.extend([
-        '-s', '{0}:{1},{2},{3}'
-            .format(NET_SLOT, i, opts['netif'], f.get('physical').strip())
+        '-s', '{0}:{1},{2},{3},feature_mask={4}'
+            .format(NET_SLOT, i, opts['netif'], f.get('physical').strip(),
+            feature_mask)
     ])
     i += 1
 


### PR DESCRIPTION
The viona feature_mask property can be used to mask out feature bits. This can be used, for example, to hide viona guest checksum capability in the case that it does not work properly in conjunction with the host physical network driver.

The use of a `net-attr` called `feature_mask` is consistent with SmartOS. See https://gist.github.com/papertigers/ca487301fff14d75d35d1dd8af252de1 (Thanks @papertigers )

An example:

```
zonecfg -z bhyve
    select net physical=bhyve0
        add property (name=feature_mask, value=2)
    end
    commit
```

Since bit 2 is the guest checksum bit:

```
#define VIRTIO_NET_F_CSUM       (1 <<  0) /* host handles partial cksum */
#define VIRTIO_NET_F_GUEST_CSUM (1 <<  1) /* guest handles partial cksum */
#define VIRTIO_NET_F_MAC        (1 <<  5) /* host supplies MAC */
...
```