### PR TITLE
Add xhci=off option for bhyve

### DIFF
--- a/src/brand/bhyve/init
+++ b/src/brand/bhyve/init
@@ -54,6 +54,7 @@ opts = {
     'netif':        'virtio-net-viona',
     'type':         'generic',
     'vnc':          'off',
+    'xhci':         '',
     'console':      '/dev/zconsole',
     'extra':        '',
 }
@@ -254,7 +255,8 @@ if len(opts['vnc']) and opts['vnc'] != 'off':
     if opts['vnc'] == 'on':
         opts['vnc'] = 'unix=/tmp/vm.vnc'
     args.extend(['-s', '{0}:0,fbuf,vga=off,{1}'.format(VNC_SLOT, opts['vnc'])])
-    args.extend(['-s', '{0}:1,xhci,tablet'.format(VNC_SLOT)])
+    if not len(opts['xhci']) or opts['xhci'] != 'off':
+        args.extend(['-s', '{0}:1,xhci,tablet'.format(VNC_SLOT)])
 
 # Pass-through devices not yet implemented
 


### PR DESCRIPTION
Some guest operating systems do not respond well to an xhci device alongside vnc.