### PR TITLE
Add flags to the information returned regarding elf dependencies.

### DIFF
--- a/src/modules/elf.c
+++ b/src/modules/elf.c
@@ -97,7 +97,7 @@ pythonify_2dliblist_cb(libnode_t *n, void *info, void *info2)
 		goto out;
 	}
 
-	if ((ent = Py_BuildValue("[s,O]", str, pverlist)) == NULL) {
+	if ((ent = Py_BuildValue("[s,O,K]", str, pverlist, n->flags)) == NULL) {
 		goto out;
 	}
 	rval = PyList_Append(pdep, ent);
@@ -548,6 +548,8 @@ moduleinit(void)
 	if (ElfError == NULL) {
 		return (NULL);
 	}
+
+	PyModule_AddIntConstant(m, "DYNFLAG_LAZY", DYNFLAG_LAZY);
 
 	Py_INCREF(ElfError);
 	PyModule_AddObject(m, "ElfError", ElfError);

--- a/src/modules/liblist.c
+++ b/src/modules/liblist.c
@@ -81,6 +81,7 @@ liblist_add(liblist_t *lst, off_t off)
 
 	n->nameoff = off;
 	n->verlist = NULL;
+	n->flags = 0;
 	n->next = NULL;
 
 	if (!lst->head) {

--- a/src/modules/liblist.h
+++ b/src/modules/liblist.h
@@ -35,10 +35,13 @@ extern "C" {
 struct libnode;
 struct liblist;
 
+#define DYNFLAG_LAZY	0x1
+
 typedef struct libnode {
 	off_t		nameoff;	/* offset of name of this node in */
 					/* a particular name table	  */
 	struct liblist	*verlist;	/* version string list head	  */
+	uint64_t	flags;
 	struct libnode	*next;		/* next node			  */
 } libnode_t;
 


### PR DESCRIPTION
This allows consumers to detect whether the dependency is lazy which
is used in kayak bin/sanity

Testsuite results match baseline
