### PR TITLE
Traceback from non-x509 file in trust anchor directory

### DIFF
--- a/src/modules/server/repository.py
+++ b/src/modules/server/repository.py
@@ -2518,7 +2518,7 @@ class _RepoStore(object):
                                             x509.load_pem_x509_certificate(
                                                 f.read(), default_backend())
                                 except ValueError as e:
-                                        pass
+                                        continue
 
                         # Note that while we store certs by their subject
                         # hashes, we use our own hashing since cryptography has


### PR DESCRIPTION
Ran testsuite both with and without a stray empty file in `/etc/ssl/pkg/` - both runs matched the baseline.
Before this change, the run with the stray file would produce test faiures.

```
# | | Traceback (most recent call last):
# | |   File "/build/tmp/pkg-omni-r151033/pkg-omni-r151033/pkg/proto/root_i386/usr/bin/pkgrepo", line 2325, in handle_errors
# | |     __ret = func(*args, **kwargs)
# | |   File "/build/tmp/pkg-omni-r151033/pkg-omni-r151033/pkg/proto/root_i386/usr/bin/pkgrepo", line 2301, in main_func
# | |     return func(conf, pargs)
# | |   File "/build/tmp/pkg-omni-r151033/pkg-omni-r151033/pkg/proto/root_i386/usr/bin/pkgrepo", line 1728, in subcmd_verify
# | |     ignored_dep_files=ignored_dep_files, progtrack=progtrack):
# | |   File "/build/tmp/pkg-omni-r151033/pkg-omni-r151033/pkg/proto/root_i386/usr/lib/python3.7/vendor-packages/pkg/server/repository.py", line 3863, in verify
# | |     use_crls=use_crls):
# | |   File "/build/tmp/pkg-omni-r151033/pkg-omni-r151033/pkg/proto/root_i386/usr/lib/python3.7/vendor-packages/pkg/server/repository.py", line 2528, in verify
# | |     trusted_ca.subject)).hexdigest()
# | | UnboundLocalError: local variable 'trusted_ca' referenced before assignment
```