### PR TITLE
Cannot view package information via depot webserver (r151032)

### DIFF
--- a/src/modules/server/depot.py
+++ b/src/modules/server/depot.py
@@ -44,6 +44,7 @@ import atexit
 import ast
 import errno
 import inspect
+import io
 import itertools
 import math
 import os
@@ -1344,10 +1345,10 @@ class DepotHTTP(_Depot):
                 pub, name, ver = pfmri.tuple()
                 summary = m.get("pkg.summary", m.get("description", ""))
 
-                lsummary = cStringIO()
+                lsummary = io.BytesIO()
                 for i, entry in enumerate(m.gen_actions_by_type("license")):
                         if i > 0:
-                                lsummary.write("\n")
+                                lsummary.write(b"\n")
                         try:
                                 lpath = self.repo.file(entry.hash, pub=pub)
                         except srepo.RepositoryFileNotFoundError:
@@ -1383,7 +1384,7 @@ License:
 {10}
 """.format(name, summary, pub, version, ver.build_release,
     ver.branch, ver.get_timestamp().strftime("%c"), misc.bytes_to_str(size),
-    misc.bytes_to_str(csize), pfmri, lsummary.read())
+    misc.bytes_to_str(csize), pfmri, misc.force_str(lsummary.read()))
 
         @cherrypy.tools.response_headers(headers=[(
             "Content-Type", p5i.MIME_TYPE)])


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/lib/python3.5/vendor-packages/cherrypy/_cprequest.py", line 628, in respond
    self._do_respond(path_info)
  File "/usr/lib/python3.5/vendor-packages/cherrypy/_cprequest.py", line 687, in _do_respond
    response.body = self.handler()
  File "/usr/lib/python3.5/vendor-packages/cherrypy/lib/encoding.py", line 219, in __call__
    self.body = self.oldhandler(*args, **kwargs)
  File "/usr/lib/python3.5/vendor-packages/cherrypy/_cpdispatch.py", line 54, in __call__
    return self.callable(*self.args, **self.kwargs)
  File "/usr/lib/python3.5/vendor-packages/pkg/server/depot.py", line 1359, in info_0
    ignore_hash=True)
  File "/usr/lib/python3.5/vendor-packages/pkg/misc.py", line 448, in gunzip_from_stream
    outfile.write(ubuf)
TypeError: string argument expected, got 'bytes'
```