### PR TITLE
Allow failed attempts to remove /

### DIFF
--- a/src/modules/actions/directory.py
+++ b/src/modules/actions/directory.py
@@ -221,7 +221,11 @@ class DirectoryAction(generic.Action):
                 try:
                         os.rmdir(path)
                 except OSError as e:
-                        if e.errno == errno.ENOENT:
+                        if e.errno == errno.EINVAL and path == '/':
+                                # This is ok, illumos will return EINVAL
+                                # for attempts to remove /
+                                pass
+                        elif e.errno == errno.ENOENT:
                                 pass
                         elif e.errno in (errno.EEXIST, errno.ENOTEMPTY):
                                 # Cannot remove directory since it's

--- a/src/modules/client/pkgplan.py
+++ b/src/modules/client/pkgplan.py
@@ -42,6 +42,7 @@ import pkg.misc
 from functools import reduce
 
 from pkg.client import global_settings
+from pkg.client.debugvalues import DebugValues
 from pkg.misc import expanddirs, get_pkg_otw_size, EmptyI
 
 logger = global_settings.logger
@@ -586,6 +587,8 @@ class PkgPlan(object):
 
         def execute_install(self, src, dest):
                 """ perform action for installation of package"""
+                if DebugValues["actions"]:
+                        print("execute_install: {} -> {}".format(src, dest))
                 self._executed = True
                 try:
                         dest.install(self, src)
@@ -602,6 +605,8 @@ class PkgPlan(object):
 
         def execute_update(self, src, dest):
                 """ handle action updates"""
+                if DebugValues["actions"]:
+                        print("execute_update: {} -> {}".format(src, dest))
                 self._executed = True
                 try:
                         dest.install(self, src)
@@ -618,6 +623,8 @@ class PkgPlan(object):
 
         def execute_removal(self, src, dest):
                 """ handle action removals"""
+                if DebugValues["actions"]:
+                        print("execute_removal: {}".format(src))
                 self._executed = True
                 try:
                         src.remove(self)


### PR DESCRIPTION
At present, it is not possible to remove the `sunpro` package because it has an installed file called `../SUNWlibC.copyright`. When pkg tries to remove the implicit `..` directory at the start, that resolves to `/` and it attempts an `os.rmdir('/')` which fails. That blocks the package uninstallation with:

```
The Boot Environment 20200125 failed to be updated. A snapshot was taken before the failed attempt and is mounted here /tmp/tmplrv5mwsu. Use 'beadm unmount 20200125-10' and then 'beadm activate 20200125-10' if you wish to boot to this BE.
```

Also adding some additional debug statements which helped to track this down.