### PR TITLE
Fix errors resulting from UTF-8 characters in manifest files

### DIFF
--- a/src/modules/manifest.py
+++ b/src/modules/manifest.py
@@ -1077,7 +1077,7 @@ class Manifest(object):
                 # together has to be solved somewhere else, though.)
                 if pathname:
                         try:
-                                with open(pathname, "r") as mfile:
+                                with open(pathname, "r", encoding='UTF-8') as mfile:
                                         content = mfile.read()
                         except EnvironmentError as e:
                                 raise apx._convert_error(e)

--- a/src/modules/search_storage.py
+++ b/src/modules/search_storage.py
@@ -75,7 +75,7 @@ def consistent_open(data_list, directory, timeout = 1):
                         # in the function is greater than timeout.
                         try:
                                 f = os.path.join(directory, d.get_file_name())
-                                fh = open(f, 'r')
+                                fh = open(f, 'r', encoding='UTF-8')
                                 # If we get here, then the current index file
                                 # is present.
                                 if missing == None:


### PR DESCRIPTION
```
[12:14:28]  <v_a_b>	  File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
[12:14:28]  <v_a_b>	    return codecs.ascii_decode(input, self.errors)[0]
[12:14:28]  <v_a_b>	UnicodeDecodeError: 'ascii' codec can't decode byte 0xc5 in position 1428: ordinal not in range(128)
```
