### PR TITLE
Adjust pkggzip.py for python 3.7.7

### DIFF
--- a/src/modules/pkggzip.py
+++ b/src/modules/pkggzip.py
@@ -22,8 +22,8 @@
 
 #
 # Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
-#ident	"%Z%%M%	%I%	%E% SMI"
 
 import gzip
 
@@ -37,7 +37,7 @@ class PkgGzipFile(gzip.GzipFile):
             fileobj=None):
 
                gzip.GzipFile.__init__(self, filename, mode, compresslevel,
-                    fileobj) 
+                    fileobj)
 
         #
         # This is a gzip header conforming to RFC1952.  The first two bytes
@@ -50,7 +50,7 @@ class PkgGzipFile(gzip.GzipFile):
         # "unknown").
         magic = b"\037\213\010\000\000\000\000\000\002\377"
 
-        def _write_gzip_header(self):
+        def _write_gzip_header(self, compresslevel=None):
                 self.fileobj.write(self.magic)
 
         @staticmethod


### PR DESCRIPTION
Python 3.7.7 has modified the gzip module - https://github.com/python/cpython/commit/12c45efe828a90a2f2f58a1f95c85d792a0d9c0a

pkg5 subclasses this to force gzipped files to have a constant header and requires an update for the new function signature.

With this change in place, I ran the testsuite with both python 3.7.6 and python 3.7.7. Both runs matched the baseline.