### PR TITLE
traceback with unicode in environment variables

### DIFF
--- a/src/modules/pspawn.py
+++ b/src/modules/pspawn.py
@@ -22,6 +22,7 @@
 
 #
 # Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 from __future__ import unicode_literals, print_function
@@ -170,9 +171,14 @@ def posix_spawnp(filename, args, fileactions=None, env=None):
     spawn_env = []
     if env:
         for arg in env:
-            if six.PY3 and isinstance(arg, six.string_types):
-                arg = arg.encode()
-            spawn_env.append(ffi.new("char []", arg))
+            try:
+                if six.PY3 and isinstance(arg, six.string_types):
+                    arg = arg.encode()
+                spawn_env.append(ffi.new("char []", arg))
+            except:
+                # If an environment variable cannot be added for any reason,
+                # just continue. (Most likely is UnicodeEncodeError)
+                pass
     spawn_env.append(ffi.NULL)
 
     # setup file actions, if passed by caller


### PR DESCRIPTION
Reported by Jaakko Linnosaari in https://gitter.im/omniosorg/Lobby

```
--- Resolving dependencies
Running: /usr/bin/pkgdepend generate -md /tmp/build_jsl/pscore-2.0.3/system_pscore_pkg -d /home/jsl/src/omnios-build/build/pscore/. /tmp/build_jsl/pscore-2.0.3/system_pscore.p5m.int.2                                                      
Running: /usr/bin/pkgdepend resolve -m /tmp/build_jsl/pscore-2.0.3/system_pscore.p5m.int.3
Traceback (most recent call last):
  File "/usr/bin/pkgdepend", line 601, in <module>
    __ret = main_func()
  File "/usr/bin/pkgdepend", line 580, in main_func
    return resolve(pargs, img_dir)
  File "/usr/bin/pkgdepend", line 315, in resolve
    exact_match=provided_image_dir)
  File "/usr/lib/python3.5/vendor-packages/pkg/client/api.py", line 379, in __init__
    cmdpath=self.cmdpath)
  File "/usr/lib/python3.5/vendor-packages/pkg/client/image.py", line 239, in __init__
    progtrack)
  File "/usr/lib/python3.5/vendor-packages/pkg/client/image.py", line 537, in find_root
    startd=startd, progtrack=progtrack)
  File "/usr/lib/python3.5/vendor-packages/pkg/client/image.py", line 1049, in __set_dirs
    self.linked._init_root()
  File "/usr/lib/python3.5/vendor-packages/pkg/client/linkedimage/common.py", line 522, in _init_root
    self.__load(tmp=False)
  File "/usr/lib/python3.5/vendor-packages/pkg/client/linkedimage/common.py", line 860, in __load
    if not props and not self.__isparent(ignore_errors=True):
  File "/usr/lib/python3.5/vendor-packages/pkg/client/linkedimage/common.py", line 1180, in __isparent
    ignore_errors=ignore_errors)) > 0
  File "/usr/lib/python3.5/vendor-packages/pkg/client/linkedimage/common.py", line 1330, in __list_children
    ignore_errors=ignore_errors):
  File "/usr/lib/python3.5/vendor-packages/pkg/client/linkedimage/zone.py", line 306, in get_child_list
    ignore_errors=ignore_errors):
  File "/usr/lib/python3.5/vendor-packages/pkg/client/linkedimage/zone.py", line 242, in __list_zones_cached
    if not self.__in_gz(ignore_errors=ignore_errors):
  File "/usr/lib/python3.5/vendor-packages/pkg/client/linkedimage/zone.py", line 159, in __in_gz
    self.__in_gz_cached = (_zonename() == ZONE_GLOBAL)
  File "/usr/lib/python3.5/vendor-packages/pkg/client/linkedimage/zone.py", line 403, in _zonename
    p = pkg.pkgsubprocess.Popen(cmd, stdout=fout, stderr=ferrout)
  File "/usr/lib/python3.5/vendor-packages/pkg/pkgsubprocess.py", line 51, in __init__
    subprocess.Popen.__init__(self, args, **kwargs)
  File "/usr/lib/python3.5/subprocess.py", line 676, in __init__
    restore_signals, start_new_session)
  File "/usr/lib/python3.5/vendor-packages/pkg/pkgsubprocess.py", line 282, in _execute_child
    env)
  File "/usr/lib/python3.5/vendor-packages/pkg/pspawn.py", line 174, in posix_spawnp
    arg = arg.encode()
UnicodeEncodeError: 'utf-8' codec can't encode character '\udce2' in position 50: surrogates not allowed
```