### PR TITLE
Add on-demand VNICs to remaining brands

### DIFF
--- a/src/brand/Makefile
+++ b/src/brand/Makefile
@@ -22,7 +22,7 @@
 #
 # Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2012, OmniTI Computer Consulting, Inc. All rights reserved.
-# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 MACH:sh = uname -p
@@ -69,7 +69,9 @@ ROOTFILES = \
 	$(ROOTETCZONES)/SUNWipkg.xml \
 	$(ROOTETCZONES)/OMNIipkg.xml \
 	\
+	$(SHAREDBRANDPKG)/firewall.ksh \
 	$(SHAREDBRANDPKG)/state.ksh \
+	$(SHAREDBRANDPKG)/vnic.ksh \
 	\
 	$(ROOTBRANDPKG)/attach \
 	$(ROOTBRANDPKG)/clone \

--- a/src/brand/bhyve/support
+++ b/src/brand/bhyve/support
@@ -9,21 +9,23 @@
 # source. A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
 
-# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
+. /usr/lib/brand/shared/common.ksh
 . /usr/lib/brand/shared/state.ksh
-. /usr/lib/brand/ipkg/common.ksh
+. /usr/lib/brand/shared/firewall.ksh
+. /usr/lib/brand/shared/vnic.ksh
 
 cmd="${1:?cmd}"
-zone="${2:?zone}"
-root="${3:?root}"
+ZONENAME="${2:?zonename}"
+ZONEPATH="${3:?zonepath}"
 shift 3
 
 bhyve_shutdown()
 {
 	typeset delay=${1:-60}
-	pkill -z "$zone" bhyve
-	while [ $delay -gt 0 ] && pgrep -z "$zone" bhyve >/dev/null; do
+	pkill -z "$ZONENAME" bhyve
+	while [ $delay -gt 0 ] && pgrep -z "$ZONENAME" bhyve >/dev/null; do
 		((delay = delay - 1))
 		sleep 1
 	done
@@ -35,19 +37,26 @@ case $cmd in
 	;;
     prestate)
 	case $1:$2 in
-	    4:4) # halting (even as part of rebooting)
+	    *:$ZONE_STATE_CMD_READY)
+		config_vnics
+		;;
+	    $ZONE_STATE_RUNNING:$ZONE_STATE_CMD_HALT)
+		# halting (even as part of rebooting)
 		bhyve_shutdown 60
 		;;
 	esac
 	;;
     poststate)
-	if [ "$2" = $ZONE_STATE_CMD_READY ]; then
-		ZONEPATH="$root"
-		ZONENAME="$zone"
-		setup_fw
-	fi
+	case $1:$2 in
+	    *:$ZONE_STATE_CMD_READY)
+		setup_firewall
+		;;
+	    *:$ZONE_STATE_CMD_HALT)
+		unconfig_vnics
+		;;
+	esac
 	;;
 esac
 
-exit 0
+exit $ZONE_SUBPROC_OK
 

--- a/src/brand/illumos/poststate
+++ b/src/brand/illumos/poststate
@@ -9,7 +9,7 @@
 # source. A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
 
-# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 . /usr/lib/brand/ipkg/common.ksh
 . /usr/lib/brand/shared/state.ksh
@@ -22,7 +22,7 @@ ALTROOT="$5"
 
 case $cmd in
     $ZONE_STATE_CMD_READY)
-	setup_fw
+	setup_firewall
 	;;
     $ZONE_STATE_CMD_HALT)
 	unconfig_network

--- a/src/brand/kvm/support
+++ b/src/brand/kvm/support
@@ -1,15 +1,30 @@
 #!/bin/ksh
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+
+. /usr/lib/brand/shared/common.ksh
+. /usr/lib/brand/shared/state.ksh
+. /usr/lib/brand/shared/vnic.ksh
 
 cmd="${1:?cmd}"
-zone="${2:?zone}"
-root="${3:?root}"
+ZONENAME="${2:?zonename}"
+ZONEPATH="${3:?zonepath}"
 shift 3
 
 qemu_shutdown()
 {
 	typeset delay=${1:-60}
-	echo system_powerdown | nc -U "$root/root/tmp/vm.monitor" >/dev/null
-	while [ $delay -gt 0 ] && pgrep -z "$zone" qemu >/dev/null; do
+	echo system_powerdown | nc -U "$ZONEPATH/root/tmp/vm.monitor" >/dev/null
+	while [ $delay -gt 0 ] && pgrep -z "$ZONENAME" qemu >/dev/null; do
 		((delay = delay - 1))
 		sleep 1
 	done
@@ -21,14 +36,23 @@ case $cmd in
 	;;
     prestate)
 	case $1:$2 in
-	    4:4) # halting (even as part of rebooting)
+	    *:$ZONE_STATE_CMD_READY)
+		config_vnics
+		;;
+	    $ZONE_STATE_RUNNING:$ZONE_STATE_CMD_HALT)
+		# halting (even as part of rebooting)
 		qemu_shutdown 60
 		;;
 	esac
 	;;
     poststate)
+        case $1:$2 in
+            *:$ZONE_STATE_CMD_HALT)
+                unconfig_vnics
+                ;;
+        esac
 	;;
 esac
 
-exit 0
+exit $ZONE_SUBPROC_OK
 

--- a/src/brand/lx/poststate
+++ b/src/brand/lx/poststate
@@ -9,10 +9,12 @@
 # source. A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
 
-# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
-. /usr/lib/brand/ipkg/common.ksh
+. /usr/lib/brand/shared/common.ksh
 . /usr/lib/brand/shared/state.ksh
+. /usr/lib/brand/shared/firewall.ksh
+. /usr/lib/brand/shared/vnic.ksh
 
 ZONENAME="$1"
 ZONEPATH="$2"
@@ -22,7 +24,10 @@ ALTROOT="$5"
 
 case $cmd in
     $ZONE_STATE_CMD_READY)
-	setup_fw
+	setup_firewall
+	;;
+    $ZONE_STATE_CMD_HALT)
+	unconfig_vnics
 	;;
 esac
 

--- a/src/brand/lx/prestate
+++ b/src/brand/lx/prestate
@@ -9,14 +9,22 @@
 # source. A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
 
-# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
+. /usr/lib/brand/shared/common.ksh
 . /usr/lib/brand/shared/state.ksh
+. /usr/lib/brand/shared/vnic.ksh
 
 ZONENAME="$1"
 ZONEPATH="$2"
 state="$3"
 cmd="$4"
 ALTROOT="$5"
+
+case $cmd in
+    $ZONE_STATE_CMD_READY)
+        config_vnics
+        ;;
+esac
 
 exit $ZONE_SUBPROC_OK

--- a/src/brand/poststate
+++ b/src/brand/poststate
@@ -1,47 +1,22 @@
 #!/bin/ksh -p
 #
-# CDDL HEADER START
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
 #
-# The contents of this file are subject to the terms of the
-# Common Development and Distribution License (the "License").
-# You may not use this file except in compliance with the License.
-#
-# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
-# or http://www.opensolaris.org/os/licensing.
-# See the License for the specific language governing permissions
-# and limitations under the License.
-#
-# When distributing Covered Code, include this CDDL HEADER in each
-# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
-# If applicable, add the following below this CDDL HEADER, with the
-# fields enclosed by brackets "[]" replaced with your own identifying
-# information: Portions Copyright [yyyy] [name of copyright owner]
-#
-# CDDL HEADER END
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
 #
 
 #
 # Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
-# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 . /usr/lib/brand/ipkg/common.ksh
-
-# States
-# ZONE_STATE_CONFIGURED           0 (never see)
-# ZONE_STATE_INCOMPLETE           1 (never see)
-# ZONE_STATE_INSTALLED            2
-# ZONE_STATE_READY                3
-# ZONE_STATE_RUNNING              4
-# ZONE_STATE_SHUTTING_DOWN        5
-# ZONE_STATE_DOWN                 6
-# ZONE_STATE_MOUNTED              7
-
-# cmd
-#
-# ready			0
-# boot			1
-# halt			4
+. /usr/lib/brand/shared/state.ksh
 
 ZONENAME=$1
 ZONEPATH=$2
@@ -50,10 +25,10 @@ cmd=$4
 ALTROOT=$5
 
 case $cmd in
-    0)		# Ready
-	setup_fw
+    $ZONE_STATE_CMD_READY)
+	setup_firewall
 	;;
-    4)		# Halting
+    $ZONE_STATE_CMD_HALT)
 	is_brand_labeled
 	if (( $? == 0 )); then
 		# Leave the active dataset mounted after halting (this might be

--- a/src/brand/prestate
+++ b/src/brand/prestate
@@ -1,46 +1,21 @@
 #!/bin/ksh -p
 #
-# CDDL HEADER START
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
 #
-# The contents of this file are subject to the terms of the
-# Common Development and Distribution License (the "License").
-# You may not use this file except in compliance with the License.
-#
-# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
-# or http://www.opensolaris.org/os/licensing.
-# See the License for the specific language governing permissions
-# and limitations under the License.
-#
-# When distributing Covered Code, include this CDDL HEADER in each
-# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
-# If applicable, add the following below this CDDL HEADER, with the
-# fields enclosed by brackets "[]" replaced with your own identifying
-# information: Portions Copyright [yyyy] [name of copyright owner]
-#
-# CDDL HEADER END
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
 
 #
 # Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
-# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 . /usr/lib/brand/ipkg/common.ksh
-
-# States
-# ZONE_STATE_CONFIGURED           0 (never see)
-# ZONE_STATE_INCOMPLETE           1 (never see)
-# ZONE_STATE_INSTALLED            2
-# ZONE_STATE_READY                3
-# ZONE_STATE_RUNNING              4
-# ZONE_STATE_SHUTTING_DOWN        5
-# ZONE_STATE_DOWN                 6
-# ZONE_STATE_MOUNTED              7
-
-# cmd
-#
-# ready			0
-# boot			1
-# halt			4
+. /usr/lib/brand/shared/state.ksh
 
 ZONENAME=$1
 ZONEPATH=$2
@@ -49,15 +24,15 @@ cmd=$4
 ALTROOT=$5
 
 case $cmd in
-    0)
+    $ZONE_STATE_CMD_READY)
 	# Going to ready state
 	# Mount active dataset on the root.
 	mount_active_ds
 	# Only configure the network if the zone is actually heading for boot
-	[ "$state" != 99 ] && config_network
+	[ "$state" != "$ZONE_STATE_SYSBOOT" ] && config_network
 	;;
 
-    1)
+    $ZONE_STATE_CMD_BOOT)
 	# Pre-boot
 	;;
 esac

--- a/src/brand/shared/firewall.ksh
+++ b/src/brand/shared/firewall.ksh
@@ -1,0 +1,53 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+
+# Set up GZ-managed firewall rules for the zone
+function setup_firewall {
+	if [ -f $ZONEPATH/etc/ipf.conf ]; then
+		ipf_conf=$ZONEPATH/etc/ipf.conf
+		ipf6_conf=$ZONEPATH/etc/ipf6.conf
+		ipnat_conf=$ZONEPATH/etc/ipnat.conf
+	elif [ -f $ZONEPATH/config/ipf.conf ]; then
+		# Joyent SmartOS uses config/
+		ipf_conf=$ZONEPATH/config/ipf.conf
+		ipf6_conf=$ZONEPATH/config/ipf6.conf
+		ipnat_conf=$ZONEPATH/config/ipnat.conf
+	else
+		return
+	fi
+
+	#log "Enabling zone firewall ($ipf_conf)"
+	ipf -GE $ZONENAME || fail_fatal "error enabling ipf"
+
+	# Flush
+	ipf -GFa $ZONENAME || fail_fatal "error flushing ipf (IPv4)"
+	ipf -6GFa $ZONENAME || fail_fatal "error flushing ipf (IPv6)"
+	ipnat -CF -G $ZONENAME >/dev/null 2>&1 || \
+	    fail_fatal "error flushing ipnat"
+
+	# IPv4
+	ipf -Gf $ipf_conf $ZONENAME || \
+	    fail_fatal "error loading ipf config for IPv4"
+
+	# IPv6
+	[ -f $ipf6_conf ] && ! ipf -6Gf $ipf6_conf $ZONENAME && \
+	    fail_fatal "error loading ipf config for IPv6"
+
+	# NAT
+	[ -f $ipnat_conf ] && ! ipnat -G $ZONENAME -f $ipnat_conf && \
+	    fail_fatal "error loading ipnat config"
+
+	ipf -Gy $ZONENAME >/dev/null 2>&1 || \
+	    fail_fatal "error syncing ipf interfaces"
+}
+

--- a/src/brand/shared/vnic.ksh
+++ b/src/brand/shared/vnic.ksh
@@ -1,0 +1,98 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+
+#
+# Retrieve a list of on-demand VNICs configured on the zone along with their
+# configuration parameters.
+#
+function demand_vnics {
+	zonecfg -z "$ZONENAME" info net | nawk '
+		function outp()	{
+					if (!shared && global != "-")
+						printf("%s %s %s %s %s\n",
+						    phys, global, mac, vlan,
+						    addr)
+				}
+		/^net:/		{
+					outp()
+					phys = global = mac = vlan = addr = "-"
+					shared = 0
+				}
+		/global-nic:/		{ global = $2 }
+		/physical:/		{ phys = $2 }
+		/mac-addr:/		{ mac = $2 }
+		/vlan-id:/		{ vlan = $2 }
+		/allowed-address:/	{ addr = $2 }
+		# If an address attribute is specified, this is a shared IP
+		# zone.
+		/\taddress:/	{ shared = 1 }
+		END		{ outp() }
+	'
+}
+
+#
+# Configure on-demand VNICs for the zone
+#
+function config_vnics {
+	demand_vnics | while read nic global mac vlan addr; do
+		[ -n "$global" -a "$global" != "-" ] || continue
+		if [ "$global" = "auto" ]; then
+			if [ "$addr" = "-" ]; then
+				fail_fatal "%s %s" \
+				    "Cannot use 'auto' global NIC" \
+				    "without allowed-address."
+			fi
+			global="`route -n get "$addr" | nawk '
+			    / interface:/ {print $2; exit}'`"
+			if [ -z "$global" ]; then
+				fail_fatal \
+				    "Could not determine global-nic for %s" \
+				    "$nic"
+			fi
+		fi
+		if dladm show-vnic -p -o LINK $nic >/dev/null 2>&1; then
+			# VNIC already exists
+			continue
+		fi
+		#echo "Creating VNIC $nic/$global (mac: $mac, vlan: $vlan)"
+
+		opt=
+		[ "$mac" != "-" ] && opt+=" -m $mac"
+		[ "$vlan" != "-" -a "$vlan" != "0" ] && opt+=" -v $vlan"
+		if ! dladm create-vnic -l $global $opt $nic; then
+			fail_fatal "Could not create VNIC %s/%s" \
+			    "$nic" "$global"
+		fi
+
+		if [ "$mac" = "-" ]; then
+			# Record the assigned MAC address in the zone config
+			mac=`dladm show-vnic -p -o MACADDRESS $nic`
+			[ -n "$mac" ] && zonecfg -z $ZONENAME \
+			    "select net physical=$nic; " \
+			    "set mac-addr=$mac; " \
+			    "end; exit"
+		fi
+	done
+}
+
+#
+# Unconfigure on-demand VNICs for the zone
+#
+function unconfig_vnics {
+	demand_vnics | while read nic global mac vlan addr; do
+		[ -n "$global" -a "$global" != "-" ] || continue
+		#echo "Removing VNIC $nic/$global"
+		dladm delete-vnic $nic || log "Could not delete VNIC $nic"
+	done
+}
+

--- a/src/brand/sparse/poststate
+++ b/src/brand/sparse/poststate
@@ -9,7 +9,7 @@
 # source. A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
 
-# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 . /usr/lib/brand/sparse/common.ksh
 . /usr/lib/brand/shared/state.ksh
@@ -27,7 +27,7 @@ case $cmd in
 	# At this point, the overlay should be mounted ready for boot.
 	find_active_ds
 	mount_overlays
-	setup_fw
+	setup_firewall
 	;;
     $ZONE_STATE_CMD_HALT)
 	# Re-mount overlays to support patching while zone is down

--- a/src/pkg/manifests/system:zones:brand:ipkg.p5m
+++ b/src/pkg/manifests/system:zones:brand:ipkg.p5m
@@ -20,6 +20,7 @@
 #
 # Copyright (c) 2010, 2011, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2012, OmniTI Computer Consulting, Inc. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 set name=pkg.fmri value=pkg:/system/zones/brand/ipkg@$(PKGVERS)
@@ -64,7 +65,9 @@ dir  path=usr/lib/brand/lx owner=root group=bin mode=0755 \
 file path=usr/lib/brand/lx/poststate mode=0755 variant.opensolaris.zone=global
 file path=usr/lib/brand/lx/prestate mode=0755 variant.opensolaris.zone=global
 dir  path=usr/lib/brand/shared group=sys
+file path=usr/lib/brand/shared/firewall.ksh
 file path=usr/lib/brand/shared/state.ksh
+file path=usr/lib/brand/shared/vnic.ksh
 legacy pkg=SUNWipkg-brand version=0.0.0
 license cr_Oracle license=cr_Oracle
 depend type=require fmri=system/extended-system-utilities pkg.linted=true


### PR DESCRIPTION
Centralise firewall and VNIC configuration.

Prior to this change, `lx`, `bhyve` and `kvm` zones did not honour the `global-nic` attribute in the zone configuration.