### PR TITLE
Populate more of the smbios type information for bhyve

### DIFF
--- a/src/brand/bhyve/init
+++ b/src/brand/bhyve/init
@@ -189,7 +189,8 @@ if opts['acpi'] == 'on':
 
 args.extend([
     '-H',
-    '-B', '1,product=OmniOS HVM',
+    '-B', '1,manufacturer={},product={},version={},serial={},sku={},family={}'
+        .format('OmniOS', 'OmniOS HVM', '1.0', uuid, '001', 'Virtual Machine'),
     '-c', opts['vcpus'],
     '-m', opts['ram'],
 ])


### PR DESCRIPTION
Before:
```
bloody2% smbios -t SMB_TYPE_SYSTEM
ID    SIZE TYPE
2     55   SMB_TYPE_SYSTEM (type 1) (system information)

  Manufacturer:
  Product: OmniOS HVM
  Version: 1.0
  Serial Number: None

  UUID: 5f253d3a-4002-f1c4-9301-e58e5f2faaf9
  Wake-Up Event: 0x6 (power switch)
  SKU Number: None
  Family:
```

After:
```
bloody% smbios -t SMB_TYPE_SYSTEM
ID    SIZE TYPE
2     105  SMB_TYPE_SYSTEM (type 1) (system information)

  Manufacturer: OmniOS
  Product: OmniOS HVM
  Version: 1.0
  Serial Number: 15d75ebd-b708-c0ef-eaa1-8670b7ce8a40

  UUID: bd5ed715-08b7-efc0-eaa1-8670b7ce8a40
  Wake-Up Event: 0x6 (power switch)
  SKU Number: 001
  Family: Virtual Machine
```