### PR TITLE
Fix two bugs with conditional dependencies (r151030)

### DIFF
--- a/src/modules/client/pkg_solver.py
+++ b/src/modules/client/pkg_solver.py
@@ -2219,11 +2219,31 @@ class PkgSolver(object):
                             dependency_action.attrs["predicate"])
                         conditional, nonmatching = self.__comb_newer_fmris(
                             cond_fmri, dotrim, obsolete_ok=obsolete_ok)
+
                         # Required is only really helpful for solver error
                         # messaging.  The only time we know that this dependency
                         # is required is when the predicate package must be part
                         # of the solution.
                         if cond_fmri.pkg_name not in self.__req_pkg_names:
+                                required = False
+
+                        proposed = (
+                            proposed_dict[cond_fmri.pkg_name]
+                            if proposed_dict and
+                            cond_fmri.pkg_name in proposed_dict
+                            else []
+                        )
+
+                        # If the predicate is not installed and not in the
+                        # proposed set, then the dependant package is not
+                        # required.
+                        installed = False
+                        for f in conditional:
+                                if (f in proposed or
+                                    f in self.__installed_fmris -
+                                    self.__removal_fmris):
+                                        installed = True
+                        if not installed:
                                 required = False
 
                         matching, nonmatching = \


### PR DESCRIPTION
1. Given - type=conditional predicate=pkg:/pkg2@1.1 fmri=pkg:/pkg6@1.1
and pkg2@1.0 installed then pkg6 is not automatically added (as expected)
However if you manually install pkg6, then you cannot uninstall it again.

2. Given - type=conditional predicate=pkg:/pkg2@1.1 fmri=pkg:/nosuch
and pkg2@1.0 is installed, one cannot install or upgrade to the package that
contains this conditional dependency.