### PR TITLE
require-any depends can trigger duplicate exception

### DIFF
--- a/src/modules/manifest.py
+++ b/src/modules/manifest.py
@@ -22,6 +22,7 @@
 
 #
 # Copyright (c) 2007, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 from __future__ import print_function
@@ -311,7 +312,8 @@ class Manifest(object):
                                                 ktype = a.attrs.\
                                                     get("predicate")
                                             key = {"{0}->{1}".format(
-                                                key_val[0], ktype)}
+                                                ','.join(sorted(key_val)),
+                                               ktype)}
                                         else:
                                             key = set(key_val)
 


### PR DESCRIPTION
This fixes a problem introduced by e896e05e8f2dc7d82f9ba239d78c262fc8454887

Seen during the full bloody build today:

```
Pushing illumos pkgs to file:///data/omnios-build/omniosorg/bloody/_repo...
Repository information
PUBLISHER PACKAGES STATUS           UPDATED
omnios    526      online           2020-09-18T13:56:01.404022Z

PROCESS                                         ITEMS    GET (MB)   SEND (MB)
system/xopen/xcu4                             304/526     1.0/1.0     0.9/0.9
pkgmerge: Duplicate action(s):
pkg://omnios/developer/build/onbld@0.5.11,5.11-151035.0:20200918T144323Z
depend fmri=pkg:/developer/gcc7 fmri=pkg:/system/library/g++-runtime type=require-any
depend fmri=pkg:/developer/gcc7 fmri=pkg:/system/library/gcc-runtime type=require-any

Leaving /data/omnios-build/omniosorg/bloody/illumos
```

Also added a new test which fails before and passes after