### PR TITLE
Remove incorrect postinstall notes from ipkg installation

### DIFF
--- a/src/brand/ipkg/common.ksh
+++ b/src/brand/ipkg/common.ksh
@@ -69,8 +69,6 @@ e_badunmount=$(gettext "Zone unmount failed")
 e_exitfail=$(gettext "Postprocessing failed.")
 
 m_complete=$(gettext    "        Done: Installation completed in %s seconds.")
-m_postnote=$(gettext    "  Next Steps: Boot the zone, then log into the zone console (zlogin -C)")
-m_postnote2=$(gettext "              to complete the configuration process.")
 
 lc_pkg() {
 	[ "$1" = "-v" ] && shift && echo "PKG: $@" 1>&2

--- a/src/brand/ipkg/image_install
+++ b/src/brand/ipkg/image_install
@@ -41,7 +41,6 @@ p2ving=$(gettext        "Postprocessing: This may take a while...")
 p2v_prog=$(gettext      "   Postprocess: ")
 p2v_done=$(gettext      "        Result: Postprocessing complete.")
 p2v_fail=$(gettext      "        Result: Postprocessing failed.")
-m_postnote3=$(gettext "              Make any other adjustments, such as disabling SMF services\n              that are no longer needed.")
 
 media_missing=\
 $(gettext "%s: you must specify an installation source using '-a' or '-d'.")
@@ -229,8 +228,5 @@ is_brand_labeled
 log ""
 log "$m_complete" ${SECONDS}
 printf "$install_log\n" "$ZONEROOT/var/log/$ZONENAME.install$$.log"
-printf "$m_postnote\n"
-printf "$m_postnote2\n"
-printf "$m_postnote3\n"
 
 exit $ZONE_SUBPROC_OK

--- a/src/brand/ipkg/pkgcreatezone
+++ b/src/brand/ipkg/pkgcreatezone
@@ -375,8 +375,7 @@ fi
 
 printf "$m_complete\n\n" ${SECONDS}
 if (( $brand_labeled == 0 )); then
-	printf "$m_postnote\n"
-	printf "$m_postnote2\n"
+	:
 else
 	# Umount the dataset on the root.
 	umount $ZONEROOT || printf "$f_zfs_unmount" "$ZONEPATH/root"


### PR DESCRIPTION
The message which is displayed after installation of an lipkg or ipkg zone is not necessary on OmniOS:

```
PHASE                                          ITEMS
Installing new actions                   60382/60382
Updating package state database                 Done
Updating package cache                           0/0
Updating image state                            Done
Creating fast lookup database                   Done
 Postinstall: Copying SMF seed repository ... done.
        Done: Installation completed in 308.098 seconds.

  Next Steps: Boot the zone, then log into the zone console (zlogin -C)
              to complete the configuration process.
```

let's remove it.