### PR TITLE
Want more informative messages when an upgrade cannot be performed

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -2296,6 +2296,53 @@ def update(op, api_inst, pargs, accept, act_timeout, backup_be, backup_be_name,
         """Attempt to take all installed packages specified to latest
         version."""
 
+        if verbose > 1:
+                # Special mode where we determine the latest version of each
+                # requested package, and pass that explicitly to the backend
+                # to elicit more meaningful error messages to aid with
+                # troubleshooting.
+
+                msg("Retrieving package list...")
+
+                packages = client_api._list_inventory(op='list',
+                    api_inst=api_inst, pargs=pargs, li_parent_sync=False,
+                    list_all=False, list_installed_newest=False,
+                    list_newest=True, list_upgradable=True,
+                    origins=set([]), quiet=True, refresh_catalogs=False);
+
+                if "data" not in packages:
+                        error("Could not retrieve package list.")
+                        return EXIT_OOPS
+
+                msg("Retrieving list of packages to update...")
+
+                updates = client_api._list_inventory(op='list',
+                    api_inst=api_inst, pargs=pargs, li_parent_sync=False,
+                    list_all=False, list_installed_newest=False,
+                    list_newest=False, list_upgradable=True,
+                    origins=set([]), quiet=True, refresh_catalogs=False);
+
+                if "data" not in updates:
+                        error("Could not retrieve list of packages to update.")
+                        return EXIT_OOPS
+
+                # Build dictionary of packages to the latest version
+                latestver = {
+                        'pkg://{0}/{1}'.format(e['pub'], e['pkg']) :
+                        e['version']
+                        for e in packages['data']
+                }
+
+                # Build list of packages to update
+                updatelist = [ 'pkg://{0}/{1}'.format(e['pub'], e['pkg'])
+                        for e in updates['data'] ]
+
+                pargs = [
+                        '{}@{}'.format(u, latestver[u])
+                        for u in updatelist
+                        if u in latestver
+                ]
+
         out_json = client_api._update(op, api_inst, pargs, accept, act_timeout,
             backup_be, backup_be_name, be_activate, be_name, force,
             ignore_missing, li_ignore, li_erecurse, li_parent_sync, new_be,

--- a/src/modules/client/pkg_solver.py
+++ b/src/modules/client/pkg_solver.py
@@ -22,6 +22,7 @@
 
 #
 # Copyright (c) 2007, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 """Provides the interfaces and exceptions needed to determine which packages
@@ -839,10 +840,8 @@ class PkgSolver(object):
                             "unable to compute solution."))
                         info.append(_("Dependency analysis is unable to "
                             "determine exact cause."))
-                        info.append(_("Try specifying expected results to "
+                        info.append(_("Try running with -vv to "
                             "obtain more detailed error messages."))
-                        info.append(_("Include specific version of packages "
-                            "you wish installed."))
                 exp.no_solution = incs + info
 
                 # Value 'DebugValues' is unsubscriptable;
@@ -1449,7 +1448,7 @@ class PkgSolver(object):
                 else:
                         info.append(_("Dependency analysis is unable to "
                             "determine the cause."))
-                        info.append(_("Try specifying expected versions to "
+                        info.append(_("Try running with -vv to "
                             "obtain more detailed error messages."))
 
                 self.__raise_solution_error(no_solution=info)

--- a/src/tests/cli/t_pkg_image_update.py
+++ b/src/tests/cli/t_pkg_image_update.py
@@ -467,6 +467,15 @@ class NoTestImageUpdate(pkg5unittest.ManyDepotTestCase):
                 # of osnet-incorporation is not possible.
                 self.pkg("update -nv osnet-incorporation", exit=4)
 
+                # With -vv, the message should always show the reason for
+                # the upgrade not being possible.
+                self.pkg("update -nvv", exit=1, assert_solution=False)
+                self.assertTrue("This version is excluded" in self.errout)
+                self.pkg("update -nvv osnet-incorporation@latest", exit=1)
+                self.assertTrue("This version is excluded" in self.errout)
+                self.pkg("update -nvv osnet-incorporation", exit=1)
+                self.assertTrue("This version is excluded" in self.errout)
+
                 # A pkg update (with no arguments) should not fail if we are a
                 # linked image child because we're likely constrained by our
                 # parent dependencies.


### PR DESCRIPTION
With IPS, it's possible to get a situation where an upgrade cannot be performed and the error message is not very informative, for example:

```
r151034% pfexec pkg update -nv
Creating Plan (Running solver): |
pkg update: No solution was found to satisfy constraints
No solution found to update to latest available versions.
This may indicate an overly constrained set of packages are installed.

latest incorporations:

  pkg://omnios/consolidation/osnet/osnet-incorporation@0.5.11,5.11-151036.0:20201002T085228Z
  pkg://omnios/developer/illumos-tools@11,5.11-151036.0:20201002T071229Z
  pkg://omnios/developer/omnios-build-tools@11,5.11-151036.0:20201002T071709Z
  pkg://omnios/entire@11,5.11-151036.0:20201002T072426Z
  pkg://omnios/incorporation/jeos/illumos-gate@11,5.11-151036.0:20201002T085700Z
  pkg://omnios/incorporation/jeos/omnios-userland@11,5.11-151036.0:20201002T072614Z

Dependency analysis is unable to determine the cause.
Try specifying expected versions to obtain more detailed error messages.
```

This change adds a new behaviour when `-v` is provided a second time, which shows a better error message that should point directly to the problem

```
r151034% pfexec pkg update -nvv
Retrieving package list...
Retrieving list of packages to update...
Creating Plan (Solver setup): /
pkg update: Package 'ooce/extra-build-tools' must be uninstalled or upgraded if the requested operation is to be performed.
  Reject:  pkg://extra.omnios/ooce/extra-build-tools@11-151034.0
  Reason:  No version for 'conditional' dependency on ooce/x11/header/xcb-protocols can be found
Package 'ooce/omnios-build-tools' must be uninstalled or upgraded if the requested operation is to be performed.
  Reject:  pkg://extra.omnios/ooce/omnios-build-tools@11-151034.0
  Reason:  No version for 'conditional' dependency on ooce/x11/header/x11-protocols can be found
```