### PR TITLE
Updates to support python 3.9

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -434,7 +434,7 @@ def usage(usage_error=None, cmd=None, retcode=EXIT_BADOPT, full=False,
 
         def print_cmds(cmd_list, cmd_dic):
                 for cmd in cmd_list:
-                        if cmd is "":
+                        if cmd == "":
                                 logger.error("")
                         else:
                                 if cmd not in cmd_dic:
@@ -445,7 +445,7 @@ def usage(usage_error=None, cmd=None, retcode=EXIT_BADOPT, full=False,
                                             "Unable to find usage str for "
                                             "{0}".format(cmd))
                                 use_txt = cmd_dic[cmd]
-                                if use_txt is not "":
+                                if use_txt != "":
                                         logger.error(
                                             "        pkg {cmd} "
                                             "{use_txt}".format(**locals()))

--- a/src/modules/actions/_actions.c
+++ b/src/modules/actions/_actions.c
@@ -21,9 +21,10 @@
 
 /*
  * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+ * Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
  */
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 #include <stdbool.h>
@@ -144,8 +145,8 @@ fromstr(PyObject *self, PyObject *args, PyObject *kwdict)
 	char *hashstr = NULL;
 	char *keystr = NULL;
 	int *slashmap = NULL;
-	int strl, typestrl;
-	int i, ks, vs, keysize;
+	Py_ssize_t i, strl, typestrl;
+	int ks, vs, keysize;
 	int smlen = 0, smpos = 0;
 	int hash_allowed;
 	bool concat = false;

--- a/src/modules/indexer.py
+++ b/src/modules/indexer.py
@@ -22,6 +22,7 @@
 
 #
 # Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 import errno
@@ -848,7 +849,7 @@ class Indexer(object):
                 finally:
                         for d in self._data_dict.values():
                                 d.close_file_handle()
-                assert res is not 0
+                assert res != 0
                 return res
 
         def rebuild_index_from_scratch(self, fmris, tmp_index_dir=None):

--- a/src/modules/lint/pkglint_action.py
+++ b/src/modules/lint/pkglint_action.py
@@ -1268,7 +1268,7 @@ class PkgActionChecker(base.ActionChecker):
         def unknown(self, action, manifest, engine, pkglint_id="004"):
                 """We should never have actions called 'unknown'."""
 
-                if action.name is "unknown":
+                if action.name == "unknown":
                         engine.error(_("unknown action found in {0}").format(
                             manifest.fmri),
                             msgid="{0}{1}".format(self.name, pkglint_id))
@@ -1425,7 +1425,7 @@ class PkgActionChecker(base.ActionChecker):
         def license(self, action, manifest, engine, pkglint_id="007"):
                 """License actions should not have path attributes."""
 
-                if action.name is "license" and "path" in action.attrs:
+                if action.name == "license" and "path" in action.attrs:
                         engine.error(
                             _("license action in {pkg} has a path attribute, "
                             "{path}").format(
@@ -1481,7 +1481,7 @@ class PkgActionChecker(base.ActionChecker):
         def username_format(self, action, manifest, engine, pkglint_id="010"):
                 """Checks username length, and format."""
 
-                if action.name is not "user":
+                if action.name != "user":
                         return
 
                 username = action.attrs["username"]

--- a/src/modules/pkgsubprocess.py
+++ b/src/modules/pkgsubprocess.py
@@ -22,9 +22,11 @@
 
 #
 # Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 import os
+import sys
 import types
 import six
 import subprocess
@@ -51,134 +53,9 @@ class Popen(subprocess.Popen):
                 subprocess.Popen.__init__(self, args, **kwargs)
 
         if "posix_spawnp" in globals():
-                if six.PY2:
-                        def _execute_child(self, args, executable, preexec_fn,
-                            close_fds, cwd, env, universal_newlines, startupinfo,
-                            creationflags, shell, to_close, p2cread, p2cwrite,
-                            c2pread, c2pwrite, errread, errwrite):
-                                """Execute program using posix spawn"""
-
-                                if isinstance(args, (str, bytes)):
-                                        args = [args]
-
-                                if shell:
-                                        args = ["/bin/sh", "-c"] + args
-
-                                if executable == None:
-                                        executable = args[0]
-
-                                sfa = SpawnFileAction()
-
-                                # Child file actions
-                                # Close parent's pipe ends
-                                closed_fds = []
-                                if p2cwrite:
-                                        sfa.add_close(p2cwrite)
-                                        closed_fds.append(p2cwrite)
-                                if c2pread:
-                                        sfa.add_close(c2pread)
-                                        closed_fds.append(c2pread)
-                                if errread:
-                                        sfa.add_close(errread)
-                                        closed_fds.append(errread)
-
-                                # When duping fds, if there arises a situation
-                                # where one of the fds is either 0, 1 or 2, it
-                                # is possible that it is overwritten (#12607).
-                                if c2pwrite == 0:
-                                        c2pwrite = os.dup(c2pwrite)
-                                if errwrite == 0 or errwrite == 1:
-                                        errwrite = os.dup(errwrite)
-
-                                # Dup fds for child
-                                if p2cread:
-                                        sfa.add_dup2(p2cread, 0)
-                                if c2pwrite:
-                                        sfa.add_dup2(c2pwrite, 1)
-                                if errwrite:
-                                        sfa.add_dup2(errwrite, 2)
-
-                                # Close pipe fds.  Make sure we don't close the
-                                # same fd more than once.
-                                if p2cread:
-                                        sfa.add_close(p2cread)
-                                        closed_fds.append(p2cread)
-                                if c2pwrite and c2pwrite not in (p2cread,):
-                                        sfa.add_close(c2pwrite)
-                                        closed_fds.append(c2pwrite)
-                                if errwrite and errwrite not in (p2cread, c2pwrite):
-                                        sfa.add_close(errwrite)
-                                        closed_fds.append(errwrite)
-
-                                if cwd != None:
-                                        os.chdir(cwd)
-
-                                if preexec_fn:
-                                        preexec_fn()
-
-                                # Close all other fds, if asked for - after
-                                # preexec_fn(), which may open FDs.
-                                if close_fds:
-                                #
-                                # This is a bit tricky.  Due to a sad
-                                # behaviour with posix_spawn in nevada
-                                # builds before the fix for 6807216 (in
-                                # nevada 110), (and perhaps on other OS's?)
-                                # you can't have two close actions close the
-                                # same FD, or an error results.  So we track
-                                # everything we have closed, then manually
-                                # fstat and close up to the max we have
-                                # closed) .  Then we close everything above
-                                # that efficiently with add_close_childfds().
-                                #
-                                        for i in range(3, max(closed_fds) + 1):
-                                                # scheduled closed already? skip
-                                                if i in closed_fds:
-                                                        continue
-                                                try:
-                                                        os.fstat(i)
-                                                        sfa.add_close(i)
-                                                        closed_fds.append(i)
-                                                except OSError:
-                                                        pass
-                                        closefrom = max([3, max(closed_fds) + 1])
-                                        sfa.add_close_childfds(closefrom)
-
-                                if env is None:
-                                        # If caller didn't pass us an environment in
-                                        # env, borrow the env that the current process
-                                        # is using.
-                                        env = os.environ.copy()
-
-                                if type(env) == dict:
-                                        # The bundled subprocess module takes a dict in
-                                        # the "env" argument.  Allow that here by doing
-                                        # the explicit conversion to a list.
-                                        env = [
-                                            "{0}={1}".format(k, v)
-                                            for k, v in six.iteritems(env)
-                                        ]
-
-                                self.pid = posix_spawnp(executable, args, sfa, env)
-
-                                self._child_created = True
-
-                                if to_close:
-                                        def _close_in_parent(fd):
-                                                os.close(fd)
-                                                to_close.remove(fd)
-                                else:
-                                        def _close_in_parent(fd):
-                                                os.close(fd)
-
-                                # Parent
-                                if p2cread and p2cwrite:
-                                        _close_in_parent(p2cread)
-                                if c2pwrite and c2pread:
-                                        _close_in_parent(c2pwrite)
-                                if errwrite and errread:
-                                        _close_in_parent(errwrite)
-                else:
+                if sys.version_info.minor >= 9:
+                        # This is the signature for the private
+                        # _execute_child() method in Python 3.9
                         def _execute_child(self, args, executable, preexec_fn,
                             close_fds,
                             pass_fds, cwd, env,
@@ -186,115 +63,144 @@ class Popen(subprocess.Popen):
                             p2cread, p2cwrite,
                             c2pread, c2pwrite,
                             errread, errwrite,
-                            restore_signals, start_new_session):
-                                if isinstance(args, (str, bytes)):
-                                        args = [args]
+                            restore_signals,
+                            gid, gids, uid, umask,
+                            start_new_session):
+                                self._pkg_execute_child(args, executable,
+                                    preexec_fn, close_fds, cwd, env, shell,
+                                    p2cread, p2cwrite, c2pread, c2pwrite,
+                                    errread, errwrite)
+                else:
+                        # This is the signature for the private
+                        # _execute_child() method in Python 3.7 & 3.8
+                        def _execute_child(self, args, executable, preexec_fn,
+                            close_fds,
+                            pass_fds, cwd, env,
+                            startupinfo, creationflags, shell,
+                            p2cread, p2cwrite,
+                            c2pread, c2pwrite,
+                            errread, errwrite,
+                            restore_signals,
+                            start_new_session):
+                                self._pkg_execute_child(args, executable,
+                                    preexec_fn, close_fds, cwd, env, shell,
+                                    p2cread, p2cwrite, c2pread, c2pwrite,
+                                    errread, errwrite)
 
-                                if shell:
-                                        args = ["/bin/sh", "-c"] + args
+        # XXX - can this be replaced by the posix_spawn() support in
+        #       subprocess? This implementation is using posix_spawnp()
+        #       via pkg.pspawn.
+        def _pkg_execute_child(self, args, executable, preexec_fn,
+            close_fds, cwd, env, shell, p2cread, p2cwrite, c2pread, c2pwrite,
+            errread, errwrite):
+                if isinstance(args, (str, bytes)):
+                        args = [args]
 
-                                if executable is None:
-                                        executable = args[0]
+                if shell:
+                        args = ["/bin/sh", "-c"] + args
 
-                                sfa = SpawnFileAction()
+                if executable is None:
+                        executable = args[0]
 
-                                # Child file actions
-                                # Close parent's pipe ends
-                                closed_fds = []
-                                if p2cwrite != -1:
-                                        sfa.add_close(p2cwrite)
-                                        closed_fds.append(p2cwrite)
-                                if c2pread != -1:
-                                        sfa.add_close(c2pread)
-                                        closed_fds.append(c2pread)
-                                if errread != -1:
-                                        sfa.add_close(errread)
-                                        closed_fds.append(errread)
+                sfa = SpawnFileAction()
 
-                                # Dup fds for child
-                                if p2cread != -1:
-                                        sfa.add_dup2(p2cread, 0)
-                                if c2pwrite != -1:
-                                        sfa.add_dup2(c2pwrite, 1)
-                                if errwrite != -1:
-                                        sfa.add_dup2(errwrite, 2)
+                # Child file actions
+                # Close parent's pipe ends
+                closed_fds = []
+                if p2cwrite != -1:
+                        sfa.add_close(p2cwrite)
+                        closed_fds.append(p2cwrite)
+                if c2pread != -1:
+                        sfa.add_close(c2pread)
+                        closed_fds.append(c2pread)
+                if errread != -1:
+                        sfa.add_close(errread)
+                        closed_fds.append(errread)
 
-                                # Close pipe fds.  Make sure we don't close the
-                                # same fd more than once, or standard fds.
-                                for fd in [p2cread, c2pwrite, errwrite]:
-                                        if fd > 2 and fd not in closed_fds:
-                                            sfa.add_close(fd)
-                                            closed_fds.append(fd)
+                # Dup fds for child
+                if p2cread != -1:
+                        sfa.add_dup2(p2cread, 0)
+                if c2pwrite != -1:
+                        sfa.add_dup2(c2pwrite, 1)
+                if errwrite != -1:
+                        sfa.add_dup2(errwrite, 2)
 
-                                if cwd is not None:
-                                        os.chdir(cwd)
+                # Close pipe fds.  Make sure we don't close the
+                # same fd more than once, or standard fds.
+                for fd in [p2cread, c2pwrite, errwrite]:
+                        if fd > 2 and fd not in closed_fds:
+                            sfa.add_close(fd)
+                            closed_fds.append(fd)
 
-                                if preexec_fn:
-                                        preexec_fn()
+                if cwd is not None:
+                        os.chdir(cwd)
 
-                                # Close all other fds, if asked for - after
-                                # preexec_fn(), which may open FDs.
-                                if close_fds:
-                                #
-                                # This is a bit tricky.  Due to a sad
-                                # behaviour with posix_spawn in nevada
-                                # builds before the fix for 6807216 (in
-                                # nevada 110), (and perhaps on other OS's?)
-                                # you can't have two close actions close the
-                                # same FD, or an error results.  So we track
-                                # everything we have closed, then manually
-                                # fstat and close up to the max we have
-                                # closed) .  Then we close everything above
-                                # that efficiently with add_close_childfds().
-                                #
-                                        # max() can't call on empty list, use a
-                                        # trick "close_fds or [0]" to return 0
-                                        # when closed_fds is empty.
-                                        for i in range(3, max(closed_fds or [0]) + 1):
-                                                # scheduled closed already? skip
-                                                if i in closed_fds:
-                                                        continue
-                                                try:
-                                                        os.fstat(i)
-                                                        sfa.add_close(i)
-                                                        closed_fds.append(i)
-                                                except OSError:
-                                                        pass
-                                        closefrom = max([3, max(closed_fds or [0]) + 1])
-                                        sfa.add_close_childfds(closefrom)
+                if preexec_fn:
+                        preexec_fn()
 
-                                if env is None:
-                                        # If caller didn't pass us an environment in
-                                        # env, borrow the env that the current process
-                                        # is using.
-                                        env = os.environ.copy()
+                # Close all other fds, if asked for - after
+                # preexec_fn(), which may open FDs.
+                if close_fds:
+                #
+                # This is a bit tricky.  Due to a sad
+                # behaviour with posix_spawn in nevada
+                # builds before the fix for 6807216 (in
+                # nevada 110), (and perhaps on other OS's?)
+                # you can't have two close actions close the
+                # same FD, or an error results.  So we track
+                # everything we have closed, then manually
+                # fstat and close up to the max we have
+                # closed) .  Then we close everything above
+                # that efficiently with add_close_childfds().
+                #
+                        # max() can't call on empty list, use a
+                        # trick "close_fds or [0]" to return 0
+                        # when closed_fds is empty.
+                        for i in range(3, max(closed_fds or [0]) + 1):
+                                # scheduled closed already? skip
+                                if i in closed_fds:
+                                        continue
+                                try:
+                                        os.fstat(i)
+                                        sfa.add_close(i)
+                                        closed_fds.append(i)
+                                except OSError:
+                                        pass
+                        closefrom = max([3, max(closed_fds or [0]) + 1])
+                        sfa.add_close_childfds(closefrom)
 
-                                if type(env) == dict:
-                                        # The bundled subprocess module takes a dict in
-                                        # the "env" argument.  Allow that here by doing
-                                        # the explicit conversion to a list.
-                                        env = [
-                                            "{0}={1}".format(k, v)
-                                            for k, v in six.iteritems(env)
-                                        ]
+                if env is None:
+                        # If caller didn't pass us an environment in
+                        # env, borrow the env that the current process
+                        # is using.
+                        env = os.environ.copy()
 
-                                self.pid = posix_spawnp(executable, args, sfa,
-                                    env)
-                                self._child_created = True
+                if type(env) == dict:
+                        # The bundled subprocess module takes a dict in
+                        # the "env" argument.  Allow that here by doing
+                        # the explicit conversion to a list.
+                        env = [
+                            "{0}={1}".format(k, v)
+                            for k, v in six.iteritems(env)
+                        ]
 
-                                # parent
-                                devnull_fd = getattr(self, "_devnull", None)
-                                if p2cread != -1 and p2cwrite != -1 and \
-                                    p2cread != devnull_fd:
-                                        os.close(p2cread)
-                                if c2pwrite != -1 and c2pread != -1 and \
-                                    c2pwrite != devnull_fd:
-                                        os.close(c2pwrite)
-                                if errwrite != -1 and errread != -1 and \
-                                    errwrite != devnull_fd:
-                                        os.close(errwrite)
-                                if devnull_fd is not None:
-                                        os.close(devnull_fd)
+                self.pid = posix_spawnp(executable, args, sfa,
+                    env)
+                self._child_created = True
+
+                # parent
+                devnull_fd = getattr(self, "_devnull", None)
+                if p2cread != -1 and p2cwrite != -1 and \
+                    p2cread != devnull_fd:
+                        os.close(p2cread)
+                if c2pwrite != -1 and c2pread != -1 and \
+                    c2pwrite != devnull_fd:
+                        os.close(c2pwrite)
+                if errwrite != -1 and errread != -1 and \
+                    errwrite != devnull_fd:
+                        os.close(errwrite)
+                if devnull_fd is not None:
+                        os.close(devnull_fd)
 
 # Vim hints
 # vim:ts=8:sw=8:et:fdm=marker

--- a/src/setup.py
+++ b/src/setup.py
@@ -21,6 +21,7 @@
 #
 # Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2012, OmniTI Computer Consulting, Inc. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 from __future__ import print_function
@@ -106,7 +107,7 @@ cffi_dir = os.path.normpath(os.path.join(pwd, "cffi_src"))
 
 # Extract Python minor version.
 py_version = '.'.join(platform.python_version_tuple()[:2])
-assert py_version in ('3.7')
+assert py_version in ('3.7', '3.9')
 py_install_dir = 'usr/lib/python' + py_version + '/vendor-packages'
 
 py64_executable = '/usr/bin/python' + py_version
@@ -1736,7 +1737,6 @@ setup(cmdclass = cmdclasses,
     ext_modules = ext_modules,
     classifiers = [
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
     ]
 )
 

--- a/src/tests/api/t_pkglint.py
+++ b/src/tests/api/t_pkglint.py
@@ -21,6 +21,7 @@
 #
 
 # Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 from . import testutils
 if __name__ == "__main__":
@@ -48,7 +49,7 @@ logger = logging.getLogger("pkglint")
 if not logger.handlers:
         logger.setLevel(logging.WARNING)
         ch = logging.StreamHandler()
-        formatter = logging.Formatter(log_fmt_string)
+        formatter = logging.Formatter(log_fmt_string, style='{')
         ch.setFormatter(formatter)
         ch.setLevel(logging.WARNING)
         logger.addHandler(ch)

--- a/src/tests/cli/t_pkg_history.py
+++ b/src/tests/cli/t_pkg_history.py
@@ -406,7 +406,7 @@ class TestPkgHistory(pkg5unittest.ManyDepotTestCase):
                 comma_events = ""
                 expected_count = 0
 
-                for ts in random.sample(keys, 3):
+                for ts in random.sample(list(keys), 3):
                         if not comma_events:
                                 comma_events = ts
                         else:

--- a/src/tests/cli/t_pkgdep.py
+++ b/src/tests/cli/t_pkgdep.py
@@ -44,12 +44,13 @@ import pkg.publish.dependencies as dependencies
 
 DDP = base.Dependency.DEPEND_DEBUG_PREFIX
 
-if six.PY2:
-        py_ver_default = "2.7"
-        py_ver_other = "3.7"
-else:
-        py_ver_default = "3.7"
-        py_ver_other = "2.7"
+py2_ver = "2.7"
+py3_ver = "{}.{}".format(sys.version_info.major, sys.version_info.minor)
+py3_suffix = "m" if sys.version_info.minor < 9 else ""
+py3_ext = "{}{}".format(py3_ver.replace('.', ''), py3_suffix)
+
+py_ver_default = py3_ver
+py_ver_other = py2_ver
 
 class TestPkgdepBasics(pkg5unittest.SingleDepotTestCase):
 
@@ -547,10 +548,10 @@ from pkg.misc import EmptyI
 """
 
         python3_so_text = """\
-#!/usr/bin/python3.7
+#!/usr/bin/python{0}
 
 import zlib
-"""
+""".format(py3_ver)
 
         python_amd_text = """\
 #!/usr/bin/amd64/python{0}
@@ -666,7 +667,7 @@ depend fmri=pkg:/satisfying_manf type=require variant.foo=baz
                 discovered.
                 """
 
-                v3 = ver.startswith("3.") and "37m"
+                v3 = ver.startswith("3.") and py3_ext
 
                 vp = self.get_ver_paths(ver, proto_area)
                 self.debug("ver_paths is {0}".format(vp))
@@ -783,7 +784,7 @@ depend fmri={dummy_fmri} {pfx}.file=python{bin_ver} {pfx}.path=usr/bin {pfx}.rea
                     include_os=include_os)
 
         if six.PY2:
-                # in this case, py_ver_default = "2.7", py_ver_other = "3.7"
+                # in this case, py_ver_default = "2.7", py_ver_other = "3.x"
                 pyver_resolve_dep_manf = """
 file NOHASH group=bin mode=0444 owner=root path=usr/lib/python{py_ver}/vendor-packages/pkg/indexer.py
 file NOHASH group=bin mode=0444 owner=root path=usr/lib/python{py_ver}/vendor-packages/pkg/__init__.py
@@ -792,7 +793,7 @@ file NOHASH group=bin mode=0444 owner=root path=usr/lib/python{py_ver}/vendor-pa
 file NOHASH group=bin mode=0755 owner=root path=usr/bin/python
 """
         else:
-                # py_ver_default = "3.7", py_ver_other = "2.7"
+                # py_ver_default = "3.x", py_ver_other = "2.7"
                 pyver_resolve_dep_manf = """
 file NOHASH group=bin mode=0444 owner=root path=usr/lib/python{py_ver}/vendor-packages/pkg/indexer.py
 file NOHASH group=bin mode=0444 owner=root path=usr/lib/python{py_ver}/vendor-packages/pkg/__init__.py
@@ -805,7 +806,8 @@ file NOHASH group=bin mode=0755 owner=root path=usr/bin/python
                 """Generate the expected results when resolving a manifest which
                 contains a file with a non-default version of python."""
 
-                v3 = py_ver_other.startswith("3.") and "37m"
+                v3 = py_ver_other.startswith("3.") and py3_ext
+
                 patterns = (
                     "{0}.py", "{0}.pyc", "{0}.pyo",
                     "{0}.so", "64/{0}.so",
@@ -3105,9 +3107,9 @@ depend fmri=pkg:/a@0,5.11-1 type=conditional
 
                 # Create a python 3.x file that imports a native module.
                 tp = self.make_manifest(
-                    self.pyver_test_manf_1.format(py_ver="3.7"))
+                    self.pyver_test_manf_1.format(py_ver=py3_ver))
                 fp = "usr/lib/python{0}/vendor-packages/pkg/" \
-                    "client/indexer.py".format("3.7")
+                    "client/indexer.py".format(py3_ver)
                 self.make_proto_text_file(fp, self.python3_so_text)
 
                 # Run generate
@@ -3125,7 +3127,8 @@ depend fmri=pkg:/a@0,5.11-1 type=conditional
                         for l in self.output.strip().splitlines()
                     )
                     if a.attrs.get(pfx + ".reason") == fp and
-                        "64/zlib.cpython-37m.so" in a.attrs[pfx + ".file"]
+                        "64/zlib.cpython-{}.so".format(py3_ext)
+                         in a.attrs[pfx + ".file"]
                 ]
                 self.assertTrue(len(acts) == 1)
 

--- a/src/tests/cli/t_pkgrepo.py
+++ b/src/tests/cli/t_pkgrepo.py
@@ -1980,7 +1980,7 @@ test2	zoo		1.0	5.11	0	20110804T203458Z	pkg://test2/zoo@1.0,5.11-0:20110804T20345
                         with open(corrupt_path, "wb") as corrupt:
                                 if valid_gzip:
                                         gz = pkg.pkggzip.PkgGzipFile(
-                                            fileobj=corrupt)
+                                            fileobj=corrupt, mode="wb")
                                         gz.write(other.read())
                                         gz.close()
                                 else:
@@ -1995,7 +1995,7 @@ test2	zoo		1.0	5.11	0	20110804T203458Z	pkg://test2/zoo@1.0,5.11-0:20110804T20345
                 with open(fixed_path, "rb") as fixed:
                         with open(fpath, "wb") as broken:
                                 gz = pkg.pkggzip.PkgGzipFile(
-                                    fileobj=broken)
+                                    fileobj=broken, mode="wb")
                                 gz.write(fixed.read())
                                 gz.close()
 
@@ -2105,7 +2105,7 @@ test2	zoo		1.0	5.11	0	20110804T203458Z	pkg://test2/zoo@1.0,5.11-0:20110804T20345
                                 else:
                                         with open(cpath, "wb") as badfile:
                                                 gz = pkg.pkggzip.PkgGzipFile(
-                                                    fileobj=badfile)
+                                                    fileobj=badfile, mode="wb")
                                                 gz.write(b"noodles")
                                                 gz.close()
                                 bad_paths.append(cpath)

--- a/src/tests/run.py
+++ b/src/tests/run.py
@@ -33,10 +33,11 @@ import sys
 from functools import reduce
 
 # We need cwd to be the same dir as our program.
-if os.path.dirname(__file__) != "" and \
-    os.path.dirname(__file__) != ".":
+
+pdir = os.path.dirname(__file__)
+if pdir != "" and pdir != "." and pdir != os.getcwd():
         os.putenv('PYEXE', sys.executable)
-        os.chdir(os.path.dirname(__file__))
+        os.chdir(pdir)
         import subprocess
         cmd = [sys.executable, "run.py"]
         cmd.extend(sys.argv[1:]) # Skip argv[0]


### PR DESCRIPTION
With these changes, running the test suite with python 3.7 still matches the baseline, and with python 3.9 there is just one failure:

```
======================================================================
BASELINE MISMATCH: The following results didn't match the baseline.
----------------------------------------------------------------------
cli.t_pkg_install.py TestPkgInstallUpgrade.test_newbe_liveroot: fail
======================================================================
```

which is due to the lack of a python 3.9 libbe module from illumos-omnios.