### PR TITLE
Ship both python 3.7 & 3.9 pkg modules, pkg still using 3.7

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -22,85 +22,57 @@
 #
 # Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
 # Copyright 2016, OmniTI Computer Consulting, Inc. All rights reserved.
-# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
-PYTHON3 = /usr/bin/python3.7
+PYVERSIONS = 3.7 3.9
+PYTESTS = $(PYVERSIONS:%=runtest/%)
 
-CODE_WS = $$(hg root 2>/dev/null || git rev-parse --show-toplevel)
+CODE_WS = $$(git rev-parse --show-toplevel)
 
 all := TARGET = all
+build := TARGET = build
 install := TARGET = install
-packages := TARGET = install
 clean := TARGET = clean
 clobber := TARGET = clobber
-lint := TARGET = lint
-clint := TARGET = clint
-pylint := TARGET = pylint
-check := TARGET = check
+packages := TARGET = install
 test := TARGET = test
-test-verbose := TARGET = test-verbose
-test-generate := TARGET = test-generate
-
-#
-# clear PYTHONPATH when invoking /usr/bin/pkg (we don't want to load any
-# pkg python modules from this workspace since they may be out of sync
-# with the pkg modules in the root filesystem).
-#
-PYLINT_VER_CMD = PYTHONPATH= /usr/bin/pkg info $(PYLINT_FMRI) | \
-		 /usr/bin/grep Version | /usr/bin/awk -F: '{print $$2}' | \
-		 /usr/bin/sed -e 's/ //g'
 
 JOBS = 8
 CC = gcc
-PYCODESTYLE = /usr/bin/pycodestyle
 
 SUBDIRS=brand zoneproxy tsol util/mkcert
 
-all: $(SUBDIRS)
-	mkdir -p $(CODE_WS)/proto/build_i386/lib.solaris-2.11-i86pc-2.6/pkg/64
-	mkdir -p $(CODE_WS)/proto/build_i386/lib.solaris-2.11-i86pc-2.6/pkg/actions/64
-	$(PYTHON3) setup.py build
+all: $(SUBDIRS) build
 
-clean: $(SUBDIRS)
-	$(PYTHON3) setup.py clean
+build: $(PYVERSIONS)
+
+install: $(SUBDIRS) $(PYVERSIONS)
+
+clean: $(SUBDIRS) $(PYVERSIONS)
 	@cd pkg; pwd; make clean
 
-clobber: $(SUBDIRS)
-	$(PYTHON3) setup.py clobber
+clobber: $(SUBDIRS) $(PYVERSONS)
 	@cd pkg; pwd; make clobber
-
-install: $(SUBDIRS)
-	CC=$(CC) $(PYTHON3) setup.py install
-
-lint:
-	CC=$(CC) $(PYTHON3) setup.py lint
-	@cd zoneproxy; pwd; make lint
-
-clint:
-	CC=$(CC) $(PYTHON3) setup.py clint
-	@cd zoneproxy; pwd; make lint
-
-pylint: install
-	PYLINT_VER=$(PYLINT_VER_CMD:sh) $(PYTHON3) setup.py pylint
-	PYLINT_VER=$(PYLINT_VER_CMD:sh) $(PYTHON3) setup.py pylint_py3k
-
-check:
-	$(PYCODESTYLE) --statistics --count `cat tests/pycodestyle-whitelist.txt`
-
-#
-# This rule propagates the current make target through all of the
-# subdirectories in $SUBDIRS.
-#
-$(SUBDIRS): FRC
-	@cd $@; pwd; $(MAKE) $(TARGET) CC=$(CC)
 
 packages: install
 	@cd pkg; pwd; $(MAKE) $(TARGET) check \
 		PATH=$(CODE_WS)/proto/root_$$(uname -p)/usr/bin:$$PATH \
 		CC=$(CC)
 
-test: install
-	-pfexec $(PYTHON3) tests/run.py -j ${JOBS}
+test: install .WAIT $(PYTESTS)
+
+$(SUBDIRS): FRC
+	@cd $@; pwd; $(MAKE) $(TARGET) CC=$(CC)
+
+$(PYVERSIONS): FRC
+	python$@ setup.py $(TARGET)
+
+$(PYTESTS): FRC
+	-pfexec python$(@F) tests/run.py -j $(JOBS)
+	-pfexec cp tests/failures.3 tests/failures.3.$(@F)
 
 FRC:
+
+.NO_PARALLEL: $(PYVERSIONS) $(PYTESTS)
+

--- a/src/pkg/Makefile
+++ b/src/pkg/Makefile
@@ -102,7 +102,7 @@ PUBLIFESTS        = $(MANIFESTS:%.p5m=$(PDIR)/%.pub)
 DEPENDED          = $(MANIFESTS:%.p5m=$(PDIR)/%.dep)
 INCORP            = consolidation\:ips\:ips-incorporation
 
-PM_TRANSFORMS     = defaults
+PM_TRANSFORMS     = defaults py39
 
 i386_DEFINES      = \
 	i386_ONLY=''    \

--- a/src/pkg/external_deps.txt
+++ b/src/pkg/external_deps.txt
@@ -15,6 +15,23 @@
     pkg:/library/python-3/rapidjson-37
     pkg:/library/python-3/six-37
     #
+    pkg:/runtime/python-39
+    pkg:/library/python-3/cffi-39
+    pkg:/library/python-3/cherrypy-39
+    pkg:/library/python-3/coverage-39
+    pkg:/library/python-3/cryptography-39
+    pkg:/library/python-3/jsonrpclib-39
+    pkg:/library/python-3/jsonschema-39
+    pkg:/library/python-3/mako-39
+    pkg:/library/python-3/ply-39
+    pkg:/library/python-3/prettytable-39
+    pkg:/library/python-3/portend-39
+    pkg:/library/python-3/pybonjour-39
+    pkg:/library/python-3/pycurl-39
+    pkg:/library/python-3/pyopenssl-39
+    pkg:/library/python-3/rapidjson-39
+    pkg:/library/python-3/six-39
+    #
     pkg:/SUNWcs
     pkg:/archiver/gnu-tar
     pkg:/developer/build/make

--- a/src/pkg/manifests/package:pkg.p5m
+++ b/src/pkg/manifests/package:pkg.p5m
@@ -22,6 +22,18 @@
 # Copyright (c) 2012, OmniTI Computer Consulting, Inc. All rights reserved.
 # Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
+#
+# The six compatibility layers cause detection problems for pkgdepend
+<transform file -> default pkg.depend.bypass-generate .*six.*>
+#
+# pkgdepend doesn't understand the relative import syntax "from .x import y",
+# so we have to bypass generating dependencies on those files.
+<transform file path=$(PYDIRVP)/pkg/actions -> \
+    set pkg.depend.bypass-generate .*>
+<transform file path=$(PYDIRVP)/pkg/portable -> \
+    set pkg.depend.bypass-generate .*>
+<transform file path=$(PYDIRVP)/pkg/client/linkedimage/(?:system|zone).py -> \
+    set pkg.depend.bypass-generate .*>
 set name=pkg.fmri value=pkg:/package/pkg@$(PKGVERS)
 set name=pkg.summary value="Image Packaging System - pkg(5)"
 set name=pkg.description \
@@ -247,6 +259,17 @@ file path=usr/share/lib/pkg/web/_themes/default/en/footer.shtml
 file path=usr/share/lib/pkg/web/_themes/default/en/head_end.shtml
 file path=usr/share/lib/pkg/web/_themes/default/en/header.shtml
 file path=usr/share/lib/pkg/web/_themes/default/feed-icon-14x14.png
+link path=usr/share/lib/pkg/web/_themes/omnios.org target=omniosce.org
+dir  path=usr/share/lib/pkg/web/_themes/omniosce.org
+dir  path=usr/share/lib/pkg/web/_themes/omniosce.org/en
+file path=usr/share/lib/pkg/web/_themes/omniosce.org/en/base.css
+file path=usr/share/lib/pkg/web/_themes/omniosce.org/en/body_end.shtml
+file path=usr/share/lib/pkg/web/_themes/omniosce.org/en/footer.shtml
+file path=usr/share/lib/pkg/web/_themes/omniosce.org/en/head_end.shtml
+file path=usr/share/lib/pkg/web/_themes/omniosce.org/en/header.shtml
+file path=usr/share/lib/pkg/web/_themes/omniosce.org/feed-icon-14x14.png
+file path=usr/share/lib/pkg/web/_themes/omniosce.org/logo_ban0.png
+file path=usr/share/lib/pkg/web/_themes/omniosce.org/logo_ban0.svg
 dir  path=usr/share/lib/pkg/web/_themes/omniti.com
 dir  path=usr/share/lib/pkg/web/_themes/omniti.com/en
 file path=usr/share/lib/pkg/web/_themes/omniti.com/en/base.css
@@ -256,17 +279,6 @@ file path=usr/share/lib/pkg/web/_themes/omniti.com/en/head_end.shtml
 file path=usr/share/lib/pkg/web/_themes/omniti.com/en/header.shtml
 file path=usr/share/lib/pkg/web/_themes/omniti.com/feed-icon-14x14.png
 file path=usr/share/lib/pkg/web/_themes/omniti.com/logo_ban0.png
-dir path=usr/share/lib/pkg/web/_themes/omniosce.org
-dir path=usr/share/lib/pkg/web/_themes/omniosce.org/en
-file path=usr/share/lib/pkg/web/_themes/omniosce.org/en/head_end.shtml
-file path=usr/share/lib/pkg/web/_themes/omniosce.org/en/base.css
-file path=usr/share/lib/pkg/web/_themes/omniosce.org/en/body_end.shtml
-file path=usr/share/lib/pkg/web/_themes/omniosce.org/en/header.shtml
-file path=usr/share/lib/pkg/web/_themes/omniosce.org/en/footer.shtml
-file path=usr/share/lib/pkg/web/_themes/omniosce.org/feed-icon-14x14.png
-file path=usr/share/lib/pkg/web/_themes/omniosce.org/logo_ban0.png
-file path=usr/share/lib/pkg/web/_themes/omniosce.org/logo_ban0.svg
-link path=usr/share/lib/pkg/web/_themes/omnios.org target=omniosce.org
 file path=usr/share/lib/pkg/web/_themes/p5i-link.png
 file path=usr/share/lib/pkg/web/_themes/pkg-block-icon.png
 file path=usr/share/lib/pkg/web/_themes/pkg-block-logo.png
@@ -409,21 +421,10 @@ file path=usr/share/pkg/transforms/smf-manifests
 dir  path=var/cache/pkg/mirror
 dir  path=var/log/pkg/mirror
 #
-# The six compatibility layers cause detection problems for pkgdepend
-<transform file -> default pkg.depend.bypass-generate .*six.*>
-#
-# pkgdepend doesn't understand the relative import syntax "from .x import y",
-# so we have to bypass generating dependencies on those files.
-<transform file path=$(PYDIRVP)/pkg/actions -> \
-    set pkg.depend.bypass-generate .*>
-<transform file path=$(PYDIRVP)/pkg/portable -> \
-    set pkg.depend.bypass-generate .*>
-<transform file path=$(PYDIRVP)/pkg/client/linkedimage/(?:system|zone).py -> \
-    set pkg.depend.bypass-generate .*>
-#
 group groupname=pkg5srv gid=97
 user username=pkg5srv gcos-field="pkg(5) server UID" group=pkg5srv password=NP \
     uid=97
+license lic_CDDL license=CDDL
 license lic_gustaebel license="MIT (Lars Gustaebel)" \
     com.oracle.info.description="portions of the tarfile module from Python 2.4" \
     com.oracle.info.name=tarfile com.oracle.info.tpno=17819 \
@@ -433,7 +434,6 @@ license lic_minisat license="MIT (MiniSAT)" \
     com.oracle.info.description="MiniSAT 1.14.1" com.oracle.info.name=MiniSAT \
     com.oracle.info.tpno=17867 com.oracle.info.version=1.14.1
 license cr_Oracle license=cr_Oracle
-license lic_CDDL license=CDDL
 # CFFI import is done in C code, so it isn't picked up by pkgdepend
 depend type=require fmri=library/python-3/cffi-37
 depend type=require fmri=library/python-3/prettytable-37

--- a/src/pkg/manifests/system:zones:brand:illumos.p5m
+++ b/src/pkg/manifests/system:zones:brand:illumos.p5m
@@ -15,7 +15,8 @@
 
 set name=pkg.fmri value=pkg:/system/zones/brand/illumos@$(PKGVERS)
 set name=pkg.summary value="Image Packaging System branded zone - illumos zones"
-set name=pkg.description value="A branded zone for running a generic illumos distribution"
+set name=pkg.description \
+    value="A branded zone for running a generic illumos distribution"
 set name=variant.arch value=$(ARCH)
 dir  path=etc
 dir  path=etc/zones

--- a/src/pkg/manifests/system:zones:brand:ipkg.p5m
+++ b/src/pkg/manifests/system:zones:brand:ipkg.p5m
@@ -48,23 +48,23 @@ dir  path=usr/lib/brand/ipkg
 file path=usr/lib/brand/ipkg/attach mode=0755
 file path=usr/lib/brand/ipkg/clone mode=0755
 file path=usr/lib/brand/ipkg/common.ksh
+# The following two items are also in stock illumos-gate. In order to
+# continue supporting onu to stock gate, these are faceted so that the
+# onu script can disable the lines in advance.
+file path=usr/lib/brand/ipkg/config.xml mode=0444 facet.onu.ooceonly=true
 file path=usr/lib/brand/ipkg/detach mode=0755
 file path=usr/lib/brand/ipkg/fmri_compare mode=0755
 file path=usr/lib/brand/ipkg/image_install mode=0755
 file path=usr/lib/brand/ipkg/p2v mode=0755
 file path=usr/lib/brand/ipkg/pkgcreatezone mode=0755
 file path=usr/lib/brand/ipkg/pkgrm.lst
+file path=usr/lib/brand/ipkg/platform.xml mode=0444 facet.onu.ooceonly=true
 file path=usr/lib/brand/ipkg/poststate mode=0755
 file path=usr/lib/brand/ipkg/prestate mode=0755
 file path=usr/lib/brand/ipkg/smf_disable.lst
 file path=usr/lib/brand/ipkg/support mode=0755
 file path=usr/lib/brand/ipkg/system-unconfigure mode=0755
 file path=usr/lib/brand/ipkg/uninstall mode=0755
-# The following two items are also in stock illumos-gate. In order to
-# continue supporting onu to stock gate, these are faceted so that the
-# onu script can disable the lines in advance.
-file path=usr/lib/brand/ipkg/config.xml mode=0444 facet.onu.ooceonly=true
-file path=usr/lib/brand/ipkg/platform.xml mode=0444 facet.onu.ooceonly=true
 dir  path=usr/lib/brand/shared group=sys
 file path=usr/lib/brand/shared/firewall.ksh
 file path=usr/lib/brand/shared/image.ksh

--- a/src/pkg/manifests/system:zones:brand:kvm.p5m
+++ b/src/pkg/manifests/system:zones:brand:kvm.p5m
@@ -31,7 +31,7 @@ link path=usr/lib/brand/kvm/socat target=../bhyve/socat
 file path=usr/lib/brand/kvm/support mode=0555
 file path=usr/lib/brand/kvm/uninstall mode=0555
 license lic_CDDL license=lic_CDDL
+depend type=require fmri=driver/virtualization/kvm
 depend type=require fmri=network/netcat
 depend type=require fmri=system/kvm
-depend type=require fmri=driver/virtualization/kvm
 depend type=require fmri=system/zones/brand/bhyve@$(PKGVERS)

--- a/src/pkg/manifests/system:zones:brand:lx.p5m
+++ b/src/pkg/manifests/system:zones:brand:lx.p5m
@@ -30,7 +30,8 @@ dir  path=usr/lib/brand/lx owner=root group=bin mode=0755 \
     variant.opensolaris.zone=global
 file path=usr/lib/brand/lx/config.xml mode=0444 variant.opensolaris.zone=global
 file path=usr/lib/brand/lx/lx_install mode=0555 variant.opensolaris.zone=global
-file path=usr/lib/brand/lx/lx_uninstall mode=0555 variant.opensolaris.zone=global
+file path=usr/lib/brand/lx/lx_uninstall mode=0555 \
+    variant.opensolaris.zone=global
 file path=usr/lib/brand/lx/platform.xml mode=0444 \
     variant.opensolaris.zone=global
 file path=usr/lib/brand/lx/poststate mode=0555 variant.opensolaris.zone=global

--- a/src/pkg/transforms/py39
+++ b/src/pkg/transforms/py39
@@ -1,0 +1,26 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+#
+
+# A temporary transform that makes it easy to ship modules from a newer
+# version of python alongside the existing ones to aid transition or
+# testing
+
+<transform file dir path=$(PYDIRVP) -> \
+  emit %(action.name) path=TBD%(path) \
+  pkg.depend.bypass-generate=%(pkg.depend.bypass-generate;notfound='notfound')>
+
+<transform path=TBD -> delete pkg.depend.bypass-generate notfound>
+<transform path=TBD -> edit path 37m? 39>
+<transform path=TBD -> edit path 3.7 3.9>
+<transform path=TBD -> edit path TBD ''>
+


### PR DESCRIPTION
With this change, the test target now runs the testsuite once under each version. Both matched the baseline.

```
% dmake -C src test

pfexec python3.7 tests/run.py -j 8

# Ran 421 tests in 1024.708s - skipped 0 tests.
# Ran 1050 tests in 2964.765s - skipped 1 tests.

======================================================================
BASELINE MATCH
======================================================================

pfexec cp tests/failures.3 tests/failures.3.3.7
pfexec python3.9 tests/run.py -j 8

# Ran 421 tests in 1050.923s - skipped 0 tests.
# Ran 1050 tests in 2627.165s - skipped 1 tests.

======================================================================
BASELINE MATCH
======================================================================

```