### PR TITLE
Switch to python 3.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,4 @@
 /src/cffi_src/_*
 /src/cffi_src/64
 /src/tests/failures
-/src/tests/failures.3
+/src/tests/failures.3*

--- a/src/brand/ipkg/fmri_compare.py
+++ b/src/brand/ipkg/fmri_compare.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/client.py
+++ b/src/client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/depot-config.py
+++ b/src/depot-config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/depot.py
+++ b/src/depot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/modules/__init__.py
+++ b/src/modules/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/actions/__init__.py
+++ b/src/modules/actions/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/actions/attribute.py
+++ b/src/modules/actions/attribute.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/actions/depend.py
+++ b/src/modules/actions/depend.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/actions/directory.py
+++ b/src/modules/actions/directory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/actions/driver.py
+++ b/src/modules/actions/driver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/actions/file.py
+++ b/src/modules/actions/file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/actions/generic.py
+++ b/src/modules/actions/generic.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/actions/group.py
+++ b/src/modules/actions/group.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/actions/hardlink.py
+++ b/src/modules/actions/hardlink.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/actions/legacy.py
+++ b/src/modules/actions/legacy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/actions/license.py
+++ b/src/modules/actions/license.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/actions/link.py
+++ b/src/modules/actions/link.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/actions/signature.py
+++ b/src/modules/actions/signature.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/actions/unknown.py
+++ b/src/modules/actions/unknown.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/actions/user.py
+++ b/src/modules/actions/user.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/altroot.py
+++ b/src/modules/altroot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/api_common.py
+++ b/src/modules/api_common.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/arch.py
+++ b/src/modules/arch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/bundle/DirectoryBundle.py
+++ b/src/modules/bundle/DirectoryBundle.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/bundle/SolarisPackageDatastreamBundle.py
+++ b/src/modules/bundle/SolarisPackageDatastreamBundle.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/bundle/SolarisPackageDirBundle.py
+++ b/src/modules/bundle/SolarisPackageDirBundle.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/bundle/TarBundle.py
+++ b/src/modules/bundle/TarBundle.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/bundle/__init__.py
+++ b/src/modules/bundle/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/catalog.py
+++ b/src/modules/catalog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/cfgfiles.py
+++ b/src/modules/cfgfiles.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/choose.py
+++ b/src/modules/choose.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 # Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008 Python Software
 # Foundation; All Rights Reserved
 #

--- a/src/modules/client/__init__.py
+++ b/src/modules/client/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/actuator.py
+++ b/src/modules/client/actuator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/api.py
+++ b/src/modules/client/api.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/api_errors.py
+++ b/src/modules/client/api_errors.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/bootenv.py
+++ b/src/modules/client/bootenv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/client_api.py
+++ b/src/modules/client/client_api.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/debugvalues.py
+++ b/src/modules/client/debugvalues.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/firmware.py
+++ b/src/modules/client/firmware.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/history.py
+++ b/src/modules/client/history.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/image.py
+++ b/src/modules/client/image.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/imageconfig.py
+++ b/src/modules/client/imageconfig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/imageplan.py
+++ b/src/modules/client/imageplan.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/imagetypes.py
+++ b/src/modules/client/imagetypes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/linkedimage/__init__.py
+++ b/src/modules/client/linkedimage/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/linkedimage/common.py
+++ b/src/modules/client/linkedimage/common.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/linkedimage/system.py
+++ b/src/modules/client/linkedimage/system.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/linkedimage/zone.py
+++ b/src/modules/client/linkedimage/zone.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/options.py
+++ b/src/modules/client/options.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/pkg_solver.py
+++ b/src/modules/client/pkg_solver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/pkgdefs.py
+++ b/src/modules/client/pkgdefs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/pkgplan.py
+++ b/src/modules/client/pkgplan.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/pkgremote.py
+++ b/src/modules/client/pkgremote.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/plandesc.py
+++ b/src/modules/client/plandesc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/printengine.py
+++ b/src/modules/client/printengine.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/progress.py
+++ b/src/modules/client/progress.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/publisher.py
+++ b/src/modules/client/publisher.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/query_parser.py
+++ b/src/modules/client/query_parser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/rad_pkg.py
+++ b/src/modules/client/rad_pkg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/sigpolicy.py
+++ b/src/modules/client/sigpolicy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/transport/__init__.py
+++ b/src/modules/client/transport/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/transport/engine.py
+++ b/src/modules/client/transport/engine.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/transport/exception.py
+++ b/src/modules/client/transport/exception.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/transport/fileobj.py
+++ b/src/modules/client/transport/fileobj.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/transport/mdetect.py
+++ b/src/modules/client/transport/mdetect.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/transport/repo.py
+++ b/src/modules/client/transport/repo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/transport/stats.py
+++ b/src/modules/client/transport/stats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/transport/transport.py
+++ b/src/modules/client/transport/transport.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/config.py
+++ b/src/modules/config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/cpiofile.py
+++ b/src/modules/cpiofile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # Copyright (C) 2002 Lars Gustaebel <lars@gustaebel.de>
 # All rights reserved.

--- a/src/modules/dependency.py
+++ b/src/modules/dependency.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/depotcontroller.py
+++ b/src/modules/depotcontroller.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/digest.py
+++ b/src/modules/digest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/facet.py
+++ b/src/modules/facet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/file_layout/__init__.py
+++ b/src/modules/file_layout/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/file_layout/file_manager.py
+++ b/src/modules/file_layout/file_manager.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/file_layout/layout.py
+++ b/src/modules/file_layout/layout.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/flavor/__init__.py
+++ b/src/modules/flavor/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/flavor/base.py
+++ b/src/modules/flavor/base.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/flavor/depthlimitedmf.py
+++ b/src/modules/flavor/depthlimitedmf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 # Copyright (c) 2001, 2016, 2003, 2016, 2005, 2016, 2007, 2016, 2009 Python
 # Software Foundation; All Rights Reserved
 #

--- a/src/modules/flavor/elf.py
+++ b/src/modules/flavor/elf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/flavor/hardlink.py
+++ b/src/modules/flavor/hardlink.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/flavor/python.py
+++ b/src/modules/flavor/python.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #
@@ -51,7 +51,7 @@ class PythonModuleMissingPath(base.DependencyAnalysisError):
 
 class PythonMismatchedVersion(base.DependencyAnalysisError):
         """Exception that is raised when a module is installed into a path
-        associated with a known version of python (/usr/lib/python3.7 for
+        associated with a known version of python (/usr/lib/python3.9 for
         example) but has a different version of python specified in its
         #! line (#!/usr/bin/python3.4 for example)."""
 

--- a/src/modules/flavor/script.py
+++ b/src/modules/flavor/script.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/flavor/smf_manifest.py
+++ b/src/modules/flavor/smf_manifest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/fmri.py
+++ b/src/modules/fmri.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/gui/repository.py
+++ b/src/modules/gui/repository.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/indexer.py
+++ b/src/modules/indexer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/json.py
+++ b/src/modules/json.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # {{{ CDDL HEADER
 #

--- a/src/modules/lint/__init__.py
+++ b/src/modules/lint/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/lint/base.py
+++ b/src/modules/lint/base.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/lint/config.py
+++ b/src/modules/lint/config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 
 #
 # CDDL HEADER START

--- a/src/modules/lint/engine.py
+++ b/src/modules/lint/engine.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/lint/log.py
+++ b/src/modules/lint/log.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/lint/opensolaris.py
+++ b/src/modules/lint/opensolaris.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/lint/pkglint_action.py
+++ b/src/modules/lint/pkglint_action.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/lint/pkglint_manifest.py
+++ b/src/modules/lint/pkglint_manifest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/lockfile.py
+++ b/src/modules/lockfile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/manifest.py
+++ b/src/modules/manifest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/mediator.py
+++ b/src/modules/mediator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/misc.py
+++ b/src/modules/misc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/mogrify.py
+++ b/src/modules/mogrify.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/nrlock.py
+++ b/src/modules/nrlock.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/p5i.py
+++ b/src/modules/p5i.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/p5p.py
+++ b/src/modules/p5p.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/p5s.py
+++ b/src/modules/p5s.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/pipeutils.py
+++ b/src/modules/pipeutils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/pkggzip.py
+++ b/src/modules/pkggzip.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/pkgsubprocess.py
+++ b/src/modules/pkgsubprocess.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/pkgtarfile.py
+++ b/src/modules/pkgtarfile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/portable/__init__.py
+++ b/src/modules/portable/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/portable/os_aix.py
+++ b/src/modules/portable/os_aix.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/portable/os_darwin.py
+++ b/src/modules/portable/os_darwin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/portable/os_sunos.py
+++ b/src/modules/portable/os_sunos.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/portable/os_unix.py
+++ b/src/modules/portable/os_unix.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/portable/os_windows.py
+++ b/src/modules/portable/os_windows.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/portable/util.py
+++ b/src/modules/portable/util.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/pspawn.py
+++ b/src/modules/pspawn.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/publish/__init__.py
+++ b/src/modules/publish/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/publish/dependencies.py
+++ b/src/modules/publish/dependencies.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/publish/transaction.py
+++ b/src/modules/publish/transaction.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/query_parser.py
+++ b/src/modules/query_parser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/search_errors.py
+++ b/src/modules/search_errors.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/search_storage.py
+++ b/src/modules/search_storage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/server/__init__.py
+++ b/src/modules/server/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/server/api.py
+++ b/src/modules/server/api.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/server/api_errors.py
+++ b/src/modules/server/api_errors.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/server/catalog.py
+++ b/src/modules/server/catalog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/server/depot.py
+++ b/src/modules/server/depot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/server/face.py
+++ b/src/modules/server/face.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/server/feed.py
+++ b/src/modules/server/feed.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/server/query_parser.py
+++ b/src/modules/server/query_parser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/server/repository.py
+++ b/src/modules/server/repository.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/server/transaction.py
+++ b/src/modules/server/transaction.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/sha512_t.py
+++ b/src/modules/sha512_t.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/smf.py
+++ b/src/modules/smf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/sysattr.py
+++ b/src/modules/sysattr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/syscallat.py
+++ b/src/modules/syscallat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/sysvpkg.py
+++ b/src/modules/sysvpkg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/updatelog.py
+++ b/src/modules/updatelog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/variant.py
+++ b/src/modules/variant.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/version.py
+++ b/src/modules/version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/pkg/manifests/package:pkg.p5m
+++ b/src/pkg/manifests/package:pkg.p5m
@@ -438,3 +438,10 @@ license cr_Oracle license=cr_Oracle
 depend type=require fmri=library/python-3/cffi-37
 depend type=require fmri=library/python-3/prettytable-37
 depend type=require fmri=web/ca-bundle
+# These usually come in as dependencies of the install/beadm package, but
+# during the transition to python 3.9, we need to ensure we have both
+# (and since we have a specific dependency on the python libbe module,
+#  it's probably a good idea anyway)
+depend type=require fmri=system/library/python/libbe-37
+depend type=require fmri=system/library/python/libbe-39
+

--- a/src/pkgdep.py
+++ b/src/pkgdep.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/pkgrepo.py
+++ b/src/pkgrepo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/publish.py
+++ b/src/publish.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/pull.py
+++ b/src/pull.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/rad-invoke.py
+++ b/src/rad-invoke.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/scripts/pkg.bat
+++ b/src/scripts/pkg.bat
@@ -26,7 +26,7 @@ setlocal
 set CMDSCRIPT=client.py
 set MY_HOME=%~dp0
 set MY_IPS_BASE=%MY_HOME%\..\..
-set PYTHONPATH=%PYTHONPATH%;%MY_IPS_BASE%\usr\lib\python3.7\vendor-packages
+set PYTHONPATH=%PYTHONPATH%;%MY_IPS_BASE%\usr\lib\python3.9\vendor-packages
 set MY_BASE=%MY_HOME%\..\..\..
 set PATH=%MY_BASE%\python;%PATH%
 set PYTHONUNBUFFERED=yes

--- a/src/scripts/pkg.depotd.bat
+++ b/src/scripts/pkg.depotd.bat
@@ -26,7 +26,7 @@ setlocal
 set CMDSCRIPT=depot.py
 set MY_HOME=%~dp0
 set MY_IPS_BASE=%MY_HOME%\..\..
-set PYTHONPATH=%PYTHONPATH%;%MY_IPS_BASE%\usr\lib\python3.7\vendor-packages
+set PYTHONPATH=%PYTHONPATH%;%MY_IPS_BASE%\usr\lib\python3.9\vendor-packages
 set MY_BASE=%MY_HOME%\..\..\..
 set PATH=%MY_BASE%\python;%PATH%
 set PYTHONUNBUFFERED=yes

--- a/src/scripts/pkg.depotd.sh
+++ b/src/scripts/pkg.depotd.sh
@@ -55,12 +55,12 @@ my_base=`cd ${my_home}/../../..; pwd`
 my_ips_base=`cd ${my_home}/../..; pwd`
 LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${my_ips_base}/usr/lib:/usr/sfw/lib
 PYTHONHOME=${my_base}/python
-PYTHONPATH=${PYTHONPATH}:${my_ips_base}/usr/lib/python3.7/vendor-packages
+PYTHONPATH=${PYTHONPATH}:${my_ips_base}/usr/lib/python3.9/vendor-packages
 PKG_REPO=${my_base}/var/pkg/repo
 PKG_HOME=${my_ips_base}/usr
 export LD_LIBRARY_PATH PYTHONHOME PYTHONPATH PKG_REPO PKG_HOME
-if [ -x ${my_base}/python/bin/python3.7 ] ; then
-  PYEXE=${my_base}/python/bin/python3.7
+if [ -x ${my_base}/python/bin/python3.9 ] ; then
+  PYEXE=${my_base}/python/bin/python3.9
 else
   PYEXE=`which python`
   unset PYTHONHOME

--- a/src/scripts/pkg.sh
+++ b/src/scripts/pkg.sh
@@ -55,11 +55,11 @@ my_base=`cd ${my_home}/../../..; pwd`
 my_ips_base=`cd ${my_home}/../..; pwd`
 LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${my_ips_base}/usr/lib
 PYTHONHOME=${my_base}/python
-PYTHONPATH=${PYTHONPATH}:${my_ips_base}/usr/lib/python3.7/vendor-packages
+PYTHONPATH=${PYTHONPATH}:${my_ips_base}/usr/lib/python3.9/vendor-packages
 PKG_HOME=${my_ips_base}/usr
 export LD_LIBRARY_PATH PYTHONHOME PYTHONPATH PKG_HOME
-if [ -x ${my_base}/python/bin/python3.7 ] ; then
-  PYEXE=${my_base}/python/bin/python3.7
+if [ -x ${my_base}/python/bin/python3.9 ] ; then
+  PYEXE=${my_base}/python/bin/python3.9
 else
   PYEXE=`which python`
   unset PYTHONHOME

--- a/src/scripts/pkgrecv.bat
+++ b/src/scripts/pkgrecv.bat
@@ -26,7 +26,7 @@ setlocal
 set CMDSCRIPT=pull.py
 set MY_HOME=%~dp0
 set MY_IPS_BASE=%MY_HOME%\..\..
-set PYTHONPATH=%PYTHONPATH%;%MY_IPS_BASE%\usr\lib\python3.7\vendor-packages
+set PYTHONPATH=%PYTHONPATH%;%MY_IPS_BASE%\usr\lib\python3.9\vendor-packages
 set MY_BASE=%MY_HOME%\..\..\..
 set PATH=%MY_BASE%\python;%PATH%
 set PYTHONUNBUFFERED=yes

--- a/src/scripts/pkgrecv.sh
+++ b/src/scripts/pkgrecv.sh
@@ -55,11 +55,11 @@ my_base=`cd ${my_home}/../../..; pwd`
 my_ips_base=`cd ${my_home}/../..; pwd`
 LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${my_ips_base}/usr/lib
 PYTHONHOME=${my_base}/python
-PYTHONPATH=${PYTHONPATH}:${my_ips_base}/usr/lib/python3.7/vendor-packages
+PYTHONPATH=${PYTHONPATH}:${my_ips_base}/usr/lib/python3.9/vendor-packages
 PKG_HOME=${my_ips_base}/usr
 export LD_LIBRARY_PATH PYTHONHOME PYTHONPATH PKG_HOME
-if [ -x ${my_base}/python/bin/python3.7 ] ; then
-  PYEXE=${my_base}/python/bin/python3.7
+if [ -x ${my_base}/python/bin/python3.9 ] ; then
+  PYEXE=${my_base}/python/bin/python3.9
 else
   PYEXE=`which python`
   unset PYTHONHOME

--- a/src/scripts/pkgsend.bat
+++ b/src/scripts/pkgsend.bat
@@ -26,7 +26,7 @@ setlocal
 set CMDSCRIPT=publish.py
 set MY_HOME=%~dp0
 set MY_IPS_BASE=%MY_HOME%\..\..
-set PYTHONPATH=%PYTHONPATH%;%MY_IPS_BASE%\usr\lib\python3.7\vendor-packages
+set PYTHONPATH=%PYTHONPATH%;%MY_IPS_BASE%\usr\lib\python3.9\vendor-packages
 set MY_BASE=%MY_HOME%\..\..\..
 set PATH=%MY_BASE%\python;%PATH%
 set PYTHONUNBUFFERED=yes

--- a/src/scripts/pkgsend.sh
+++ b/src/scripts/pkgsend.sh
@@ -55,11 +55,11 @@ my_base=`cd ${my_home}/../../..; pwd`
 my_ips_base=`cd ${my_home}/../..; pwd`
 LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${my_ips_base}/usr/lib
 PYTHONHOME=${my_base}/python
-PYTHONPATH=${PYTHONPATH}:${my_ips_base}/usr/lib/python3.7/vendor-packages
+PYTHONPATH=${PYTHONPATH}:${my_ips_base}/usr/lib/python3.9/vendor-packages
 PKG_HOME=${my_ips_base}/usr
 export LD_LIBRARY_PATH PYTHONHOME PYTHONPATH PKG_HOME
-if [ -x ${my_base}/python/bin/python3.7 ] ; then
-  PYEXE=${my_base}/python/bin/python3.7
+if [ -x ${my_base}/python/bin/python3.9 ] ; then
+  PYEXE=${my_base}/python/bin/python3.9
 else
   PYEXE=`which python`
   unset PYTHONHOME

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/sign.py
+++ b/src/sign.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/sysrepo.py
+++ b/src/sysrepo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_api_search.py
+++ b/src/tests/api/t_api_search.py
@@ -56,7 +56,7 @@ class TestApiSearchBasics(pkg5unittest.SingleDepotTestCase):
             open example_pkg@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/bin
             add dir mode=0755 owner=root group=bin path=/bin/example_dir
-            add dir mode=0755 owner=root group=bin path=/usr/lib/python3.7/vendor-packages/OpenSSL
+            add dir mode=0755 owner=root group=bin path=/usr/lib/python3.9/vendor-packages/OpenSSL
             add file tmp/example_file mode=0555 owner=root group=bin path=/bin/example_path
             add link path=/bin/exlink target=/bin/example_path mediator=example mediator-version=7.0 mediator-implementation=unladen-swallow
             add set name=com.sun.service.incorporated_changes value="6556919 6627937"
@@ -185,7 +185,7 @@ close
         ])
 
         res_remote_openssl = set([
-            ("pkg:/example_pkg@1.0-0", "basename", "dir group=bin mode=0755 owner=root path=usr/lib/python3.7/vendor-packages/OpenSSL")
+            ("pkg:/example_pkg@1.0-0", "basename", "dir group=bin mode=0755 owner=root path=usr/lib/python3.9/vendor-packages/OpenSSL")
         ])
 
         res_remote_bug_id = set([

--- a/src/tests/api/t_dependencies.py
+++ b/src/tests/api/t_dependencies.py
@@ -70,7 +70,7 @@ class TestDependencyAnalyzer(pkg5unittest.Pkg5TestCase):
             "script_path": "lib/svc/method/svc-pkg-depot",
             "syslog_path": "var/log/syslog",
             "py_mod_path": "usr/lib/python2.7/vendor-packages/cProfile.py",
-            "py_mod_path35": "usr/lib/python3.7/vendor-packages/cProfile.py"
+            "py_mod_path39": "usr/lib/python3.9/vendor-packages/cProfile.py"
         }
 
         smf_paths = {
@@ -138,7 +138,7 @@ file NOHASH group=bin mode=0755 owner=root path={pkg_path}
 
         python_mod_manf = """ \
 file NOHASH group=bin mode=0755 owner=root path={py_mod_path}
-file NOHASH group=bin mode=0755 owner=root path={py_mod_path35}
+file NOHASH group=bin mode=0755 owner=root path={py_mod_path39}
 """.format(**paths)
 
         relative_ext_depender_manf = """ \

--- a/src/tests/api/t_misc.py
+++ b/src/tests/api/t_misc.py
@@ -159,7 +159,7 @@ except MemoryError:
                 with open(tmpfile, 'w') as f:
                         f.write(waste_mem_py)
 
-                res = int(subprocess.check_output(['python3.7', tmpfile]))
+                res = int(subprocess.check_output(['python3.9', tmpfile]))
                 # convert from kB to bytes
                 res *= 1024
 
@@ -173,7 +173,7 @@ except MemoryError:
 
                 # test if env var works
                 os.environ["PKG_CLIENT_MAX_PROCESS_SIZE"] = str(mem_cap * 2)
-                res = int(subprocess.check_output(['python3.7', tmpfile]))
+                res = int(subprocess.check_output(['python3.9', tmpfile]))
                 res *= 1024
 
                 self.debug("mem_cap:   " + str(mem_cap * 2))
@@ -190,7 +190,7 @@ except MemoryError:
 
                 # test if invalid env var is handled correctly
                 os.environ["PKG_CLIENT_MAX_PROCESS_SIZE"] = "octopus"
-                res = int(subprocess.check_output(['python3.7', tmpfile]))
+                res = int(subprocess.check_output(['python3.9', tmpfile]))
                 res *= 1024
 
                 self.debug("mem_cap:   " + str(mem_cap))

--- a/src/tests/cli/t_pkg_mediated.py
+++ b/src/tests/cli/t_pkg_mediated.py
@@ -198,8 +198,8 @@ class TestPkgMediated(pkg5unittest.SingleDepotTestCase):
             close
             open pkg://test/runtime/python-unladen-swallow-35@3.5.0
             add set name=pkg.summary value="Example python versioned implementation package"
-            add file tmp/foopyus path=/usr/bin/python3.7-unladen-swallow owner=root group=bin mode=0555
-            add link path=/usr/bin/python target=python3.7-unladen-swallow mediator=python mediator-version=3.5 mediator-implementation=unladen-swallow@3.5
+            add file tmp/foopyus path=/usr/bin/python3.9-unladen-swallow owner=root group=bin mode=0555
+            add link path=/usr/bin/python target=python3.9-unladen-swallow mediator=python mediator-version=3.5 mediator-implementation=unladen-swallow@3.5
             close """
 
         pkg_multi_python = """
@@ -951,7 +951,7 @@ python\tlocal\t2.7\tlocal\t\t
                 self.pkg("verify")
                 self.pkg("set-mediator -vvv "
                     "-V '' -I unladen-swallow@3.5 python")
-                check_target(gen_python_links(), "python3.7-unladen-swallow")
+                check_target(gen_python_links(), "python3.9-unladen-swallow")
                 self.__assert_mediation_matches("""\
 python\tsystem\t3.5\tlocal\tunladen-swallow@3.5\t
 """)
@@ -960,7 +960,7 @@ python\tsystem\t3.5\tlocal\tunladen-swallow@3.5\t
                 # Set mediation to unladen-swallow and verify
                 # unladen-swallow@3.5 remains selected.
                 self.pkg("set-mediator -vvv -I unladen-swallow python")
-                check_target(gen_python_links(), "python3.7-unladen-swallow")
+                check_target(gen_python_links(), "python3.9-unladen-swallow")
                 self.__assert_mediation_matches("""\
 python\tsystem\t3.5\tlocal\tunladen-swallow\t3.5
 """)

--- a/src/tests/cli/t_pkg_search.py
+++ b/src/tests/cli/t_pkg_search.py
@@ -58,7 +58,7 @@ class TestPkgSearchBasics(pkg5unittest.SingleDepotTestCase):
             open example_pkg@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/bin
             add dir mode=0755 owner=root group=bin path=/bin/example_dir
-            add dir mode=0755 owner=root group=bin path=/usr/lib/python3.7/vendor-packages/OpenSSL
+            add dir mode=0755 owner=root group=bin path=/usr/lib/python3.9/vendor-packages/OpenSSL
             add file tmp/example_file mode=0555 owner=root group=bin path=/bin/example_path
             add set name=com.sun.service.incorporated_changes value="6556919 6627937"
             add set name=com.sun.service.random_test value=42 value=79
@@ -158,7 +158,7 @@ close
 
         res_remote_openssl = set([
             headers,
-            "basename   dir       usr/lib/python3.7/vendor-packages/OpenSSL pkg:/example_pkg@1.0-0\n"
+            "basename   dir       usr/lib/python3.9/vendor-packages/OpenSSL pkg:/example_pkg@1.0-0\n"
         ])
 
         res_remote_bug_id = set([

--- a/src/tests/cli/t_pkgsign.py
+++ b/src/tests/cli/t_pkgsign.py
@@ -80,7 +80,7 @@ class TestPkgSign(pkg5unittest.SingleDepotTestCase):
             open example_pkg@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/bin
             add dir mode=0755 owner=root group=bin path=/bin/example_dir
-            add dir mode=0755 owner=root group=bin path=/usr/lib/python3.7/vendor-packages/OpenSSL
+            add dir mode=0755 owner=root group=bin path=/usr/lib/python3.9/vendor-packages/OpenSSL
             add file tmp/example_file mode=0555 owner=root group=bin path=/bin/example_path
             add set name=com.sun.service.incorporated_changes value="6556919 6627937"
             add set name=com.sun.service.random_test value=42 value=79
@@ -2889,7 +2889,7 @@ class TestPkgSignMultiDepot(pkg5unittest.ManyDepotTestCase):
             open example_pkg@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/bin
             add dir mode=0755 owner=root group=bin path=/bin/example_dir
-            add dir mode=0755 owner=root group=bin path=/usr/lib/python3.7/vendor-packages/OpenSSL
+            add dir mode=0755 owner=root group=bin path=/usr/lib/python3.9/vendor-packages/OpenSSL
             add file tmp/example_file mode=0555 owner=root group=bin path=/bin/example_path
             add set name=com.sun.service.incorporated_changes value="6556919 6627937"
             add set name=com.sun.service.random_test value=42 value=79

--- a/src/util/publish/pkgdiff.py
+++ b/src/util/publish/pkgdiff.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/util/publish/pkgfmt.py
+++ b/src/util/publish/pkgfmt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/util/publish/pkglint.py
+++ b/src/util/publish/pkglint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/util/publish/pkgmerge.py
+++ b/src/util/publish/pkgmerge.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/util/publish/pkgmogrify.py
+++ b/src/util/publish/pkgmogrify.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/util/publish/pkgsurf.py
+++ b/src/util/publish/pkgsurf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/util/publish/update_file_layout.py
+++ b/src/util/publish/update_file_layout.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/util/qual-simulator/Makefile
+++ b/src/util/qual-simulator/Makefile
@@ -23,7 +23,7 @@
 #
 
 run: stats.py
-	python3.7 scenario.py
+	python3.9 scenario.py
 
 stats.py:
 	cp ../../modules/client/transport/stats.py .

--- a/src/zoneproxy/Makefile.constants
+++ b/src/zoneproxy/Makefile.constants
@@ -22,7 +22,7 @@
 # Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
 #
 
-INSTALL =	/usr/bin/python3.7 ../../setup.py installfile
+INSTALL =	/usr/bin/python3.9 ../../setup.py installfile
 CC =		gcc
 LINT =		lint
 MKDIR =		mkdir -p


### PR DESCRIPTION
This PR switches to running IPS under python 3.9 by default, mostly updating shebang lines since the python 3.9 modules are already shipped. To allow time for transition, particularly for people who use OmniOS bloody to build illumos-gate, the python 3.7 modules are still included for now.

Testsuite baseline matches under python 3.7 and python 3.9.

