### PR TITLE
Refactor catalogue and JSON code.

### DIFF
--- a/src/man/pkgrepo.1
+++ b/src/man/pkgrepo.1
@@ -728,6 +728,21 @@ A URI that represents the location of a document (such as a web page) that provi
 .ne 2
 .mk
 .na
+\fBrepository/format\fR
+.ad
+.sp .6
+.RS 4n
+The format used for storing catalogue files. The default value is \fIascii\fR
+which is the legacy format and should not be changed unless the repository
+will be accessed solely by updated clients. The other available value is
+\fIutf8\fR which allows clients to parse the catalogues faster and with less
+memory overhead.
+.RE
+
+.sp
+.ne 2
+.mk
+.na
 \fBrepository/legal_uris\fR
 .ad
 .sp .6

--- a/src/modules/catalog.py
+++ b/src/modules/catalog.py
@@ -1688,7 +1688,10 @@ class Catalog(object):
                                 if Catalog.DEPENDENCY in info_needed:
                                         yield a
                         elif Catalog.SUMMARY in info_needed and a.name == "set":
-                                if attr_name in ("fmri", "pkg.fmri"):
+                                if attr_name in ("fmri", "pkg.fmri",
+                                    "publisher") or attr_name.startswith((
+                                    "info.source-url", "pkg.debug",
+                                    "pkg.linted")):
                                         continue
 
                                 comps = attr_name.split(":")
@@ -2108,6 +2111,12 @@ class Catalog(object):
                                         continue
                                 elif name in ("fmri", "pkg.fmri"):
                                         # Redundant in the case of the catalog.
+                                        continue
+
+                                if name in ("fmri", "pkg.fmri",
+                                    "publisher") or name.startswith((
+                                    "info.source-url", "pkg.debug",
+                                    "pkg.linted")):
                                         continue
 
                                 # All other set actions go to the summary

--- a/src/modules/catalog.py
+++ b/src/modules/catalog.py
@@ -182,6 +182,10 @@ class _JSONWriter(object):
                 for l in iterable:
                         self.__sha_1.update(l)
 
+        def __str__(self):
+                if self.pathname:
+                        return 'JSONWriter to {}'.format(self.pathname)
+                return 'JSONWriter to memory'
 
 class CatalogPartBase(object):
         """A CatalogPartBase object is an abstract class containing core

--- a/src/modules/json.py
+++ b/src/modules/json.py
@@ -18,79 +18,92 @@
 json module abstraction for the packaging system.
 """
 
-############################################################################
-# Standard version
+from pkg.client.debugvalues import DebugValues
+import pkg.misc as misc
 
-from rapidjson import loads, load, dumps, dump, JSONDecodeError
+# Pass-through to jsonschema
 from jsonschema import validate, ValidationError
 
-############################################################################
-# Debug/profiling version
+import os, sys, time
+import rapidjson as _json
 
-##from pkg.client.debugvalues import DebugValues
-##import pkg.misc as misc
-##
-##import os, time
-##import rapidjson as _json
-##
-##JSONDecodeError = _json.JSONDecodeError
-##
-##def _start():
-##    global rss, start
-##    psinfo = misc.ProcFS.psinfo()
-##    rss = psinfo.pr_rssize
-##    start = time.time()
-##
-##def _end(func, param, ret):
-##    taken = time.time() - start
-##    psinfo = misc.ProcFS.psinfo()
-##    mem = (psinfo.pr_rssize - rss) / 1024.0
-##    print("JSON Mem +{:.2f} MiB - Time {:.2f}s - {}({}) = {}"
-##        .format(mem, taken, func, param, ret))
-##
-##def _file(stream):
-##        try:
-##            name = stream.name
-##            size = os.path.getsize(name) / (1024.0 * 1024.0)
-##            return "{:.2f} MiB {}".format(size, name)
-##        except:
-##            return str(stream)
-##
-##def load(stream, **kw):
-##    if "json" in DebugValues:
-##        _start()
-##        ret = _json.load(stream, **kw)
-##        _end('load', _file(stream), '')
-##        return ret
-##    else:
-##        return _json.load(stream, **kw)
-##
-##def loads(str, **kw):
-##    if "json" in DebugValues:
-##        _start()
-##        ret = _json.loads(str, **kw)
-##        _end('loads', len(str), '')
-##        return ret
-##    else:
-##        return _json.loads(str, **kw)
-##
-##def dump(obj, stream, **kw):
-##    if "json" in DebugValues:
-##        _start()
-##        ret = _json.dump(obj, stream, **kw)
-##        _end('dump', _file(stream), ret)
-##        return ret
-##    else:
-##        return _json.dump(obj, stream, **kw)
-##
-##def dumps(obj, **kw):
-##    if "json" in DebugValues:
-##        _start()
-##        ret = _json.dumps(obj, **kw)
-##        _end('dumps', '', len(ret))
-##        return ret
-##    else:
-##        return _json.dumps(obj, **kw)
+JSONDecodeError = _json.JSONDecodeError
+
+def _start():
+    psinfo = misc.ProcFS.psinfo()
+    _start.rss = psinfo.pr_rssize
+    _start.start = time.time()
+    if int(DebugValues['json']) > 1:
+        _start.trace = True
+_start.rss = 0
+_start.maxrss = 0
+_start.start = 0
+_start.trace = False
+
+def _end(func, param, ret):
+    taken = time.time() - _start.start
+    psinfo = misc.ProcFS.psinfo()
+    mem = (psinfo.pr_rssize - _start.rss) / 1024.0
+    if psinfo.pr_rssize > _start.maxrss:
+        _start.maxrss = psinfo.pr_rssize
+    print("JSON Mem {:.2f}+{:.2f}={:.2f} Max {:.2f} MiB "
+        "- Time {:.2f}s - {}({}) = {}"
+        .format(_start.rss / 1024.0, mem, psinfo.pr_rssize / 1024.0,
+        _start.maxrss / 1024.0, taken, func, param, ret),
+        file=sys.stderr)
+
+def _stack(note, limit=5):
+    from traceback import extract_stack, format_list
+    stack = extract_stack(limit=limit)[:-3]
+    print("{}:".format(note), file=sys.stderr)
+    for l in format_list(stack):
+        for m in l.split("\n"):
+            if m.strip() == '': continue
+            print("    >> {}".format(m), file=sys.stderr)
+
+def _file(stream):
+    try:
+        name = stream.name
+        size = os.path.getsize(name) / (1024.0 * 1024.0)
+        return "{:.2f} MiB {}".format(size, name)
+    except:
+        return str(stream)
+
+def load(stream, **kw):
+    if "json" in DebugValues:
+        _start()
+        ret = _json.load(stream, **kw)
+        _end('load', _file(stream), '')
+        return ret
+    else:
+        return _json.load(stream, **kw)
+
+def loads(str, **kw):
+    if "json" in DebugValues:
+        _start()
+        ret = _json.loads(str, **kw)
+        _end('loads', len(str), '')
+        return ret
+    else:
+        return _json.loads(str, **kw)
+
+def dump(obj, stream, **kw):
+    if "json" in DebugValues:
+        _start()
+        ret = _json.dump(obj, stream, **kw)
+        _end('dump', _file(stream), ret)
+        return ret
+    else:
+        return _json.dump(obj, stream, **kw)
+
+def dumps(obj, **kw):
+    if "json" in DebugValues:
+        _start()
+        ret = _json.dumps(obj, **kw)
+        _end('dumps', '', len(ret))
+        return ret
+    else:
+        return _json.dumps(obj, **kw)
 
 # Vim hints
 # vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_catalog.py
+++ b/src/tests/api/t_catalog.py
@@ -1164,6 +1164,25 @@ class TestEmptyCatalog(pkg5unittest.Pkg5TestCase):
 
 class TestCatalogueFormats(pkg5unittest.Pkg5TestCase):
 
+        def test_catalogue_ascii_hex(self):
+                # Check that an ascii-encoded unicode point containing hex
+                # digits is properly encoded. simplejson uses lower case
+                # hex digits and the switch to rapidjson started using
+                # upper-case. This test confirms that the JSON serialiser
+                # is using lower case (or the checksum will not match)
+                c = catalog.Catalog(meta_root=self.test_root)
+                f = fmri.PkgFmri("pkg:/test@1.0,5.11-1:20070101T120000Z")
+                f.set_publisher("opensolaris.org")
+                m = manifest.Manifest()
+                m.set_content(
+                    "set name=pkg.fmri value={}\n"
+                    "set name=pkg.summary value=\"Jon K\u00F6gl\"\n"
+                    .format(f), signatures=True)
+                c.add_package(f, manifest=m)
+                c.save(fmt='ascii')
+                self.assertEqual(c.signatures['catalog.summary.C'],
+                    {'sha-1': '4991afea14ad5e4c990a05a3d3f287eacc62f37c'})
+
         def test_catalogue_formats(self):
                 # Create catalogue
                 c = catalog.Catalog(meta_root=self.test_root)


### PR DESCRIPTION
```
bloody:pkg5:json% more src/tests/failures.3.*
::::::::::::::
src/tests/failures.3.3.7
::::::::::::::

======================================================================
BASELINE MISMATCH: The following results didn't match the baseline.
----------------------------------------------------------------------
api.t_catalog.py TestCatalogueFormats.test_catalogue_ascii_hex: fail
======================================================================

::::::::::::::
src/tests/failures.3.3.9
::::::::::::::

======================================================================
BASELINE MATCH
======================================================================
```

Expected since the 3.7 rapidjson module has not been patched.