### PR TITLE
apply-hot-fix origin cleanup still not right

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -421,6 +421,7 @@ def usage(usage_error=None, cmd=None, retcode=EXIT_BADOPT, full=False,
         priv_usage["audit-linked"] = _(
             "[-H] [-a|-l <li-name>] [--no-parent-sync]")
         priv_usage["pubcheck-linked"] = ""
+        priv_usage["clean-up-hot-fix"] = ""
         priv_usage["sync-linked"] = _(
             "[-nvq] [-C n] [--accept] [--licenses] [--no-index]\n"
             "            [--no-refresh] [--no-parent-sync] [--no-pkg-updates]\n"
@@ -1977,7 +1978,8 @@ class RemoteDispatch(object):
                     PKG_OP_INSTALL,
                     PKG_OP_CHANGE_FACET,
                     PKG_OP_CHANGE_VARIANT,
-                    PKG_OP_UNINSTALL
+                    PKG_OP_UNINSTALL,
+                    PKG_OP_HOTFIX_CLEANUP
                 ]
                 if op not in op_supported:
                         raise Exception(
@@ -2353,6 +2355,10 @@ def apply_hot_fix(**args):
         if not args['pargs']:
                usage(_("Source URL or file must be specified"), cmd=args['op'])
 
+        err = hotfix_cleanup(op=None, api_inst=args['api_inst'], pargs=None)
+        if err != EXIT_OK:
+                return err
+
         origin = misc.parse_uri(args['pargs'].pop(0), cwd=orig_cwd)
 
         if args['verbose']:
@@ -2529,12 +2535,9 @@ def apply_hot_fix(**args):
                 if rel == "child"
         ])
 
-        cleanup_pubargs = pubargs.copy()
-        cleanup_pubargs['remove_origins'] = pubargs['add_origins']
-        cleanup_pubargs['add_origins'] = set([])
-
         publisher_set(**pubargs)
-        atexit.register(publisher_set, **cleanup_pubargs)
+        atexit.register(hotfix_cleanup, op=None, api_inst=args['api_inst'],
+            pargs=None)
 
         ######################################################################
         # Pass off to pkg update
@@ -4629,6 +4632,21 @@ def pubcheck_linked(op, api_inst, pargs):
 
         return EXIT_OK
 
+def hotfix_cleanup(op, api_inst, pargs):
+        try:
+                api_inst.hotfix_origin_cleanup()
+        except api_errors.ImageLockedError as e:
+                error(e)
+                return EXIT_LOCKED
+        except api_errors.ImageMissingKeyFile as e:
+                error(e)
+                return EXIT_EACCESS
+        except api_errors.UnprivilegedUserError as e:
+                error(e)
+                return EXIT_OOPS
+
+        return EXIT_OK
+
 def __parse_linked_props(args, op):
         """"Parse linked image property options that were specified on the
         command line into a dictionary.  Make sure duplicate properties were
@@ -5665,6 +5683,7 @@ cmds = {
     "property"              : [property_list],
     "property-linked"       : [list_property_linked],
     "pubcheck-linked"       : [pubcheck_linked, 0],
+    "clean-up-hot-fix"      : [hotfix_cleanup, 0],
     "publisher"             : [publisher_list],
     "purge-history"         : [history_purge],
     "rebuild-index"         : [rebuild_index],
@@ -5691,6 +5710,13 @@ cmds = {
     "variant"               : [list_variant],
     "verify"                : [verify],
     "version"               : [None],
+}
+
+aliases = {
+    "image-update"          : "update",
+    "apply-hotfix"          : "apply-hot-fix",
+    "cleanup-hotfix"        : "clean-up-hot-fix",
+    "cleanup-hot-fix"       : "clean-up-hot-fix",
 }
 
 # Option value dictionary which pre-defines the valid values for
@@ -5829,8 +5855,8 @@ def main_func():
         subcommand = None
         if pargs:
                 subcommand = pargs.pop(0)
-                # 'image-update' is an alias for 'update' for compatibility.
-                subcommand = subcommand.replace("image-update", "update")
+                if subcommand in aliases:
+                        subcommand = aliases[subcommand]
                 if subcommand == "help":
                         if pargs:
                                 sub = pargs.pop(0)

--- a/src/modules/client/api.py
+++ b/src/modules/client/api.py
@@ -1705,6 +1705,21 @@ in the environment or by setting simulate_cmdpath in DebugValues.""")
                 # check that linked image pubs are in sync
                 self.__linked_pubcheck()
 
+        @_LockedCancelable()
+        def hotfix_origin_cleanup(self):
+
+                # grab image lock. Cleanup is handled by the decorator.
+                self._img.lock(allow_unprivileged=False)
+
+                # prepare for recursion
+                self._img.linked.api_recurse_init()
+
+                # clean up the image
+                self._img.hotfix_origin_cleanup()
+
+                # clean up children
+                self._img.linked.api_recurse_hfo_cleanup(self.__progresstracker)
+
         def planned_nothingtodo(self, li_ignore_all=False):
                 """Once an operation has been planned check if there is
                 something todo.

--- a/src/modules/client/options.py
+++ b/src/modules/client/options.py
@@ -21,7 +21,7 @@
 #
 
 # Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
-# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 import os
 
@@ -1347,6 +1347,7 @@ pkg_op_opts = {
     pkgdefs.PKG_OP_UNSET_PUBLISHER: None,
     pkgdefs.PKG_OP_UPDATE         : opts_update,
     pkgdefs.PKG_OP_APPLY_HOT_FIX  : opts_apply_hot_fix,
+    pkgdefs.PKG_OP_HOTFIX_CLEANUP : [],
     pkgdefs.PKG_OP_VERIFY         : opts_verify
 }
 

--- a/src/modules/client/pkgdefs.py
+++ b/src/modules/client/pkgdefs.py
@@ -22,6 +22,7 @@
 
 #
 # Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 """
@@ -71,6 +72,7 @@ PKG_OP_UNINSTALL       = "uninstall"
 PKG_OP_UNSET_PUBLISHER = "unset-publisher"
 PKG_OP_UPDATE          = "update"
 PKG_OP_APPLY_HOT_FIX   = "apply-hot-fix"
+PKG_OP_HOTFIX_CLEANUP  = "clean-up-hot-fix"
 PKG_OP_VERIFY          = "verify"
 pkg_op_values          = frozenset([
     PKG_OP_ATTACH,
@@ -98,7 +100,8 @@ pkg_op_values          = frozenset([
     PKG_OP_UNSET_PUBLISHER,
     PKG_OP_UPDATE,
     PKG_OP_APPLY_HOT_FIX,
-    PKG_OP_VERIFY
+    PKG_OP_HOTFIX_CLEANUP,
+    PKG_OP_VERIFY,
 ])
 
 API_OP_ATTACH         = "attach-linked"

--- a/src/modules/client/progress.py
+++ b/src/modules/client/progress.py
@@ -2167,9 +2167,14 @@ class CommandLineProgressTracker(ProgressTracker):
                         self.__generic_start(
                             _("Linked image publisher check ..."))
                         return
+                elif self.linked_pkg_op == pkgdefs.PKG_OP_HOTFIX_CLEANUP:
+                        self.__generic_start(
+                            _("Cleaning up hot-fix origins ..."))
+                        return
 
         def _li_recurse_end_output(self):
-                if self.linked_pkg_op == pkgdefs.PKG_OP_PUBCHECK:
+                if self.linked_pkg_op in [pkgdefs.PKG_OP_PUBCHECK,
+                    pkgdefs.PKG_OP_HOTFIX_CLEANUP]:
                         self.__generic_done()
                         return
                 self._pe.cprint(self._phase_prefix() +
@@ -2198,7 +2203,8 @@ class CommandLineProgressTracker(ProgressTracker):
                 self.__li_dump_output(stderr)
 
         def _li_recurse_status_output(self, done):
-                if self.linked_pkg_op == pkgdefs.PKG_OP_PUBCHECK:
+                if self.linked_pkg_op in [pkgdefs.PKG_OP_PUBCHECK,
+                    pkgdefs.PKG_OPT_HOTFIX_CLEANUP]:
                         return
 
                 running = " ".join([str(i) for i in self.linked_running])
@@ -2210,7 +2216,8 @@ class CommandLineProgressTracker(ProgressTracker):
                 self._pe.cprint(self._phase_prefix() + msg)
 
         def _li_recurse_progress_output(self, lin):
-                if self.linked_pkg_op == pkgdefs.PKG_OP_PUBCHECK:
+                if self.linked_pkg_op in [pkgdefs.PKG_OP_PUBCHECK,
+                    pkgdefs.PKG_OPT_HOTFIX_CLEANUP]:
                         return
 
         def _reversion(self, pfmri, outspec):
@@ -2560,9 +2567,14 @@ class RADProgressTracker(CommandLineProgressTracker):
                         self.__generic_start(
                             _("Linked image publisher check ..."))
                         return
+                elif self.linked_pkg_op == pkgdefs.PKG_OP_HOTFIX_CLEANUP:
+                        self.__generic_start(
+                            _("Cleaning up hot-fix origins ..."))
+                        return
 
         def _li_recurse_end_output(self):
-                if self.linked_pkg_op == pkgdefs.PKG_OP_PUBCHECK:
+                if self.linked_pkg_op in [pkgdefs.PKG_OP_PUBCHECK,
+                    pkgdefs.PKG_OPT_HOTFIX_CLEANUP]:
                         self.__generic_done()
                         return
                 prog_json = self.__prep_prog_json(
@@ -2585,7 +2597,8 @@ class RADProgressTracker(CommandLineProgressTracker):
                 self.__handle_prog_output(prog_json)
 
         def _li_recurse_status_output(self, done):
-                if self.linked_pkg_op == pkgdefs.PKG_OP_PUBCHECK:
+                if self.linked_pkg_op in [pkgdefs.PKG_OP_PUBCHECK,
+                    pkgdefs.PKG_OPT_HOTFIX_CLEANUP]:
                         return
 
                 prog_json = {self.O_PHASE: self._phase_prefix(),
@@ -2599,7 +2612,8 @@ class RADProgressTracker(CommandLineProgressTracker):
                 self.__handle_prog_output(prog_json)
 
         def _li_recurse_progress_output(self, lin):
-                if self.linked_pkg_op == pkgdefs.PKG_OP_PUBCHECK:
+                if self.linked_pkg_op in [pkgdefs.PKG_OP_PUBCHECK,
+                    pkgdefs.PKG_OPT_HOTFIX_CLEANUP]:
                         return
 
         def _reversion(self, pfmri, outspec):
@@ -3093,9 +3107,14 @@ class FancyUNIXProgressTracker(ProgressTracker):
                         self.__generic_start(
                             _("Linked image publisher check"))
                         return
+                elif self.linked_pkg_op == pkgdefs.PKG_OP_HOTFIX_CLEANUP:
+                        self.__generic_start(
+                            _("Cleaning up hot-fix origins ..."))
+                        return
 
         def _li_recurse_end_output(self):
-                if self.linked_pkg_op == pkgdefs.PKG_OP_PUBCHECK:
+                if self.linked_pkg_op in [pkgdefs.PKG_OP_PUBCHECK,
+                    pkgdefs.PKG_OP_HOTFIX_CLEANUP]:
                         return
                 msg = _("{phasename} linked: {numdone} done").format(
                     phasename=self.li_phase_names[self.major_phase],
@@ -3128,7 +3147,8 @@ class FancyUNIXProgressTracker(ProgressTracker):
                 self.__li_dump_output(stderr)
 
         def _li_recurse_status_output(self, done):
-                if self.linked_pkg_op == pkgdefs.PKG_OP_PUBCHECK:
+                if self.linked_pkg_op in [pkgdefs.PKG_OP_PUBCHECK,
+                    pkgdefs.PKG_OP_HOTFIX_CLEANUP]:
                         return
 
                 assert self.major_phase in self.li_phase_names, self.major_phase
@@ -3146,7 +3166,8 @@ class FancyUNIXProgressTracker(ProgressTracker):
                     itertools.repeat(0, len(self.linked_running)))
 
         def _li_recurse_progress_output(self, lin):
-                if self.linked_pkg_op == pkgdefs.PKG_OP_PUBCHECK:
+                if self.linked_pkg_op in [pkgdefs.PKG_OP_PUBCHECK,
+                    pkgdefs.PKG_OP_HOTFIX_CLEANUP]:
                         return
                 if not self._ptimer.time_to_print():
                         return


### PR DESCRIPTION
Tested on bloody - testsuite matches baseline (including new test).

Tested:
* apply a hotfix that does not require a reboot - origins were properly cleaned up in the GZ and linked NGZs;
* same but with `--be-name=xxx` to force a new BE - origins were properly cleaned up in both the old and new BE;
* apply a hotfix which requires a reboot. Again, everything was left in a clean state with no stale origins.
