### PR TITLE
Support python cryptography >= 2.4

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -156,7 +156,7 @@ def cleanup():
                 os.unlink(f)
 
 def notes_block(release_url=None):
-        url = "https://omniosce.org/"
+        url = "https://omnios.org/"
         if release_url is None:
                 release_url = misc.get_release_notes_url()
         msg("\n" + "-" * 79)


### PR DESCRIPTION
Ran the pkg5 testsuite with cryptography 2.4 and 2.3. The results matched the baseline for both.