### PR TITLE
pkg5: more s/omniosce/omnios/

### DIFF
--- a/src/brand/pkgsrc/postinstall
+++ b/src/brand/pkgsrc/postinstall
@@ -12,19 +12,19 @@
 # http://www.illumos.org/license/CDDL.
 # }}}
 
-# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
 
 . /usr/lib/brand/sparse/common.ksh
 
 ZONEROOT="${1?zoneroot}"
 
-mirror=https://mirrors.omniosce.org/pkgsrc
+mirror=https://mirrors.omnios.org/pkgsrc
 strap=bootstrap.tar.gz
 cachestrap=/var/tmp/$strap
 
 # Download bootstrap checksum each time in case of corruption or if the
 # upstream version has changed.
-curl -so $ZONEROOT/$strap.sha256 $mirror/$strap.sha256 \
+curl -Lso $ZONEROOT/$strap.sha256 $mirror/$strap.sha256 \
     || exit $ZONE_SUBPROC_NOTCOMPLETE
 strapsum="`cat $ZONEROOT/$strap.sha256`"
 
@@ -35,7 +35,7 @@ fi
 
 if [ ! -f $cachestrap ]; then
 	echo "Downloading pkgsrc bootstrap..."
-	curl -o $cachestrap.$$ $mirror/$strap || exit $ZONE_SUBPROC_NOTCOMPLETE
+	curl -Lo $cachestrap.$$ $mirror/$strap || exit $ZONE_SUBPROC_NOTCOMPLETE
 	mv $cachestrap.$$ $cachestrap || exit $ZONE_SUBPROC_NOTCOMPLETE
 fi
 

--- a/src/man/ja_JP/pkgrepo.1
+++ b/src/man/ja_JP/pkgrepo.1
@@ -976,7 +976,7 @@ $ \fBpkgrepo create /my/repository\fR
 $ \fBpkgrepo info -s /my/repository\fR
 PUBLISHER   PACKAGES STATUS UPDATED
 example.com 5        online 2011-07-22T18:09:09.769106Z
-$ \fBpkgrepo info -s https://pkg.omniosce.org/r151022/core/\fR
+$ \fBpkgrepo info -s https://pkg.omnios.org/r151022/core/\fR
 PUBLISHER PACKAGES STATUS           UPDATED
 omnios    697      online           2017-07-11T21:58:08.054608Z
 .fi
@@ -1021,7 +1021,7 @@ $ \fBpkgrepo get -s /my/repository\fR
 SECTION    PROPERTY VALUE
 publisher  prefix   ""
 repository version  4
-$ \fBpkgrepo get -s https://pkg.omniosce.org/r151022/core/\fR
+$ \fBpkgrepo get -s https://pkg.omnios.org/r151022/core/\fR
 SECTION    PROPERTY                     VALUE
 publisher  prefix                       omnios
 repository check-certificate-revocation False
@@ -1037,7 +1037,7 @@ repository version                      4
 .sp
 .in +2
 .nf
-$ \fBpkgrepo get -s https://pkg.omniosce.org/r151022/core/ -p all\fR
+$ \fBpkgrepo get -s https://pkg.omnios.org/r151022/core/ -p all\fR
 PUBLISHER SECTION    PROPERTY         VALUE
 omnios    publisher  alias
 omnios    publisher  prefix           omnios

--- a/src/man/pkg.1
+++ b/src/man/pkg.1
@@ -4290,7 +4290,7 @@ into a new boot environment called \fItestbe\fR.
 .nf
 $ \fBpkg apply-hot-fix --be-name=testbe \e\fR
 .in +4
-\fBhttps://downloads.omniosce.org/pkg/bloody/hotfix-1234.p5p\fR
+\fBhttps://downloads.omnios.org/pkg/bloody/hotfix-1234.p5p\fR
 .in -4
 .fi
 .in -2

--- a/src/man/pkgrecv.1
+++ b/src/man/pkgrecv.1
@@ -441,12 +441,12 @@ $ \fBpkgrecv -s /export/repo -d /local/repo -r editor/gnu-emacs\fR
 \fBExample 7 \fRRetrieve Additional Packages and Changed Content
 .sp
 .LP
-Receive all packages that do not already exist and all changed content from the repository located at \fBhttps://pkg.omniosce.org/bloody/core/\fR to the repository located at \fB/export/bloody\fR.
+Receive all packages that do not already exist and all changed content from the repository located at \fBhttps://pkg.omnios.org/bloody/core/\fR to the repository located at \fB/export/bloody\fR.
 
 .sp
 .in +2
 .nf
-$ \fBpkgrecv -s https://pkg.omniosce.org/bloody/core/ \e\fR
+$ \fBpkgrecv -s https://pkg.omnios.org/bloody/core/ \e\fR
 \fB-d /export/bloody -m all-timestamps '*'\fR
 .fi
 .in -2
@@ -454,12 +454,12 @@ $ \fBpkgrecv -s https://pkg.omniosce.org/bloody/core/ \e\fR
 
 .sp
 .LP
-Receive all packages that do not already exist and all changed content from the secure repository located at \fBhttps://pkg.omniosce.org/bloody/core/\fR to the repository located at \fB/export/bloody\fR.
+Receive all packages that do not already exist and all changed content from the secure repository located at \fBhttps://pkg.omnios.org/bloody/core/\fR to the repository located at \fB/export/bloody\fR.
 
 .sp
 .in +2
 .nf
-$ \fBpkgrecv -s https://pkg.omniosce.org/bloody/core/ \e\fR
+$ \fBpkgrecv -s https://pkg.omnios.org/bloody/core/ \e\fR
 \fB-d /export/bloody -m all-timestamps \e\fR
 \fB--key /var/pkg/ssl/Your-Organization.key.pem \e\fR
 \fB--cert /var/pkg/ssl/Your-Organization.certificate.pem '*'\fR

--- a/src/man/pkgrepo.1
+++ b/src/man/pkgrepo.1
@@ -1088,7 +1088,7 @@ Display a summary of publishers and the number of packages in a repository.
 $ \fBpkgrepo info -s /my/repository\fR
 PUBLISHER   PACKAGES STATUS UPDATED
 example.com 5        online 2011-07-22T18:09:09.769106Z
-$ \fBpkgrepo info -s https://pkg.omniosce.org/r151022/core/\fR
+$ \fBpkgrepo info -s https://pkg.omnios.org/r151022/core/\fR
 PUBLISHER PACKAGES STATUS           UPDATED
 omnios    697      online           2017-07-11T21:58:08.054608Z
 .fi
@@ -1133,7 +1133,7 @@ $ \fBpkgrepo get -s /my/repository\fR
 SECTION    PROPERTY VALUE
 publisher  prefix   ""
 repository version  4
-$ \fBpkgrepo get -s https://pkg.omniosce.org/r151022/core/\fR
+$ \fBpkgrepo get -s https://pkg.omnios.org/r151022/core/\fR
 SECTION    PROPERTY                     VALUE
 publisher  prefix                       omnios
 repository check-certificate-revocation False
@@ -1149,7 +1149,7 @@ repository version                      4
 .sp
 .in +2
 .nf
-$ \fBpkgrepo get -s https://pkg.omniosce.org/r151022/core/ -p all\fR
+$ \fBpkgrepo get -s https://pkg.omnios.org/r151022/core/ -p all\fR
 PUBLISHER SECTION    PROPERTY         VALUE
 omnios    publisher  alias
 omnios    publisher  prefix           omnios

--- a/src/man/zh_CN/pkgrepo.1
+++ b/src/man/zh_CN/pkgrepo.1
@@ -976,7 +976,7 @@ $ \fBpkgrepo create /my/repository\fR
 $ \fBpkgrepo info -s /my/repository\fR
 PUBLISHER   PACKAGES STATUS UPDATED
 example.com 5        online 2011-07-22T18:09:09.769106Z
-$ \fBpkgrepo info -s https://pkg.omniosce.org/r151022/core/\fR
+$ \fBpkgrepo info -s https://pkg.omnios.org/r151022/core/\fR
 PUBLISHER PACKAGES STATUS           UPDATED
 omnios    697      online           2017-07-11T21:58:08.054608Z
 .fi
@@ -1021,7 +1021,7 @@ $ \fBpkgrepo get -s /my/repository\fR
 SECTION    PROPERTY VALUE
 publisher  prefix   ""
 repository version  4
-$ \fBpkgrepo get -s https://pkg.omniosce.org/r151022/core/\fR
+$ \fBpkgrepo get -s https://pkg.omnios.org/r151022/core/\fR
 SECTION    PROPERTY                     VALUE
 publisher  prefix                       omnios
 repository check-certificate-revocation False
@@ -1037,7 +1037,7 @@ repository version                      4
 .sp
 .in +2
 .nf
-$ \fBpkgrepo get -s https://pkg.omniosce.org/r151022/core/ -p all\fR
+$ \fBpkgrepo get -s https://pkg.omnios.org/r151022/core/ -p all\fR
 PUBLISHER SECTION    PROPERTY         VALUE
 omnios    publisher  alias
 omnios    publisher  prefix           omnios

--- a/src/modules/gui/repository.py
+++ b/src/modules/gui/repository.py
@@ -90,7 +90,7 @@ class Repository(progress.GuiProgressTracker):
                 self.priority_changes = []
                 self.url_err = None
                 self.name_error = None
-                self.publisher_info = _("e.g. https://pkg.omniosce.org/r151022/core")
+                self.publisher_info = _("e.g. https://pkg.omnios.org/r151030/core")
                 self.publishers_list = None
                 self.repository_modify_publisher = None
                 self.no_changes = 0

--- a/src/modules/misc.py
+++ b/src/modules/misc.py
@@ -121,7 +121,7 @@ def get_release_notes_url():
 
         # TBD: replace with a call to api.info() that can return a "release"
         # attribute of form YYYYMM against the SUNWsolnm package
-        return "https://omniosce.org/releasenotes"
+        return "https://omnios.org/releasenotes"
 
 def time_to_timestamp(t):
         """convert seconds since epoch to %Y%m%dT%H%M%SZ format"""

--- a/src/po/de.po
+++ b/src/po/de.po
@@ -2964,8 +2964,8 @@ msgid "_View"
 msgstr "_Ansicht"
 
 #: ../gui/data/packagemanager.ui.glade.h:169 ../modules/gui/repository.py:90
-msgid "e.g. https://pkg.omniosce.org/r151022/core"
-msgstr "z. B. https://pkg.omniosce.org/r151022/core"
+msgid "e.g. https://pkg.omnios.org/r151022/core"
+msgstr "z. B. https://pkg.omnios.org/r151022/core"
 
 #: ../gui/data/packagemanager.ui.h:170
 msgid "label"

--- a/src/po/es.po
+++ b/src/po/es.po
@@ -2964,8 +2964,8 @@ msgid "_View"
 msgstr "_Ver"
 
 #: ../gui/data/packagemanager.ui.glade.h:169 ../modules/gui/repository.py:90
-msgid "e.g. https://pkg.omniosce.org/r151022/core"
-msgstr "por ejemplo, https://pkg.omniosce.org/r151022/core"
+msgid "e.g. https://pkg.omnios.org/r151022/core"
+msgstr "por ejemplo, https://pkg.omnios.org/r151022/core"
 
 #: ../gui/data/packagemanager.ui.h:170
 msgid "label"

--- a/src/po/fr.po
+++ b/src/po/fr.po
@@ -2964,8 +2964,8 @@ msgid "_View"
 msgstr "_Vue"
 
 #: ../gui/data/packagemanager.ui.glade.h:169 ../modules/gui/repository.py:90
-msgid "e.g. https://pkg.omniosce.org/r151022/core"
-msgstr "Par ex. https://pkg.omniosce.org/r151022/core"
+msgid "e.g. https://pkg.omnios.org/r151022/core"
+msgstr "Par ex. https://pkg.omnios.org/r151022/core"
 
 #: ../gui/data/packagemanager.ui.h:170
 msgid "label"

--- a/src/po/it.po
+++ b/src/po/it.po
@@ -2964,8 +2964,8 @@ msgid "_View"
 msgstr "_Visualizza"
 
 #: ../gui/data/packagemanager.ui.glade.h:169 ../modules/gui/repository.py:90
-msgid "e.g. https://pkg.omniosce.org/r151022/core"
-msgstr "es: https://pkg.omniosce.org/r151022/core"
+msgid "e.g. https://pkg.omnios.org/r151022/core"
+msgstr "es: https://pkg.omnios.org/r151022/core"
 
 #: ../gui/data/packagemanager.ui.h:170
 msgid "label"

--- a/src/po/ja.po
+++ b/src/po/ja.po
@@ -2964,8 +2964,8 @@ msgid "_View"
 msgstr "表示(_V)"
 
 #: ../gui/data/packagemanager.ui.glade.h:169 ../modules/gui/repository.py:90
-msgid "e.g. https://pkg.omniosce.org/r151022/core"
-msgstr "例: https://pkg.omniosce.org/r151022/core"
+msgid "e.g. https://pkg.omnios.org/r151022/core"
+msgstr "例: https://pkg.omnios.org/r151022/core"
 
 #: ../gui/data/packagemanager.ui.h:170
 msgid "label"

--- a/src/po/ko.po
+++ b/src/po/ko.po
@@ -2964,8 +2964,8 @@ msgid "_View"
 msgstr "보기(_V)"
 
 #: ../gui/data/packagemanager.ui.glade.h:169 ../modules/gui/repository.py:90
-msgid "e.g. https://pkg.omniosce.org/r151022/core"
-msgstr "예: https://pkg.omniosce.org/r151022/core"
+msgid "e.g. https://pkg.omnios.org/r151022/core"
+msgstr "예: https://pkg.omnios.org/r151022/core"
 
 #: ../gui/data/packagemanager.ui.h:170
 msgid "label"

--- a/src/po/pt_BR.po
+++ b/src/po/pt_BR.po
@@ -2964,8 +2964,8 @@ msgid "_View"
 msgstr "_Ver"
 
 #: ../gui/data/packagemanager.ui.glade.h:169 ../modules/gui/repository.py:90
-msgid "e.g. https://pkg.omniosce.org/r151022/core"
-msgstr "ex.: https://pkg.omniosce.org/r151022/core"
+msgid "e.g. https://pkg.omnios.org/r151022/core"
+msgstr "ex.: https://pkg.omnios.org/r151022/core"
 
 #: ../gui/data/packagemanager.ui.h:170
 msgid "label"

--- a/src/po/zh_CN.po
+++ b/src/po/zh_CN.po
@@ -2964,8 +2964,8 @@ msgid "_View"
 msgstr "查看(_V)"
 
 #: ../gui/data/packagemanager.ui.glade.h:169 ../modules/gui/repository.py:90
-msgid "e.g. https://pkg.omniosce.org/r151022/core"
-msgstr "例如 https://pkg.omniosce.org/r151022/core"
+msgid "e.g. https://pkg.omnios.org/r151022/core"
+msgstr "例如 https://pkg.omnios.org/r151022/core"
 
 #: ../gui/data/packagemanager.ui.h:170
 msgid "label"

--- a/src/po/zh_HK.po
+++ b/src/po/zh_HK.po
@@ -2964,8 +2964,8 @@ msgid "_View"
 msgstr "檢視(_V)"
 
 #: ../gui/data/packagemanager.ui.glade.h:169 ../modules/gui/repository.py:90
-msgid "e.g. https://pkg.omniosce.org/r151022/core"
-msgstr "例如 https://pkg.omniosce.org/r151022/core"
+msgid "e.g. https://pkg.omnios.org/r151022/core"
+msgstr "例如 https://pkg.omnios.org/r151022/core"
 
 #: ../gui/data/packagemanager.ui.h:170
 msgid "label"

--- a/src/po/zh_TW.po
+++ b/src/po/zh_TW.po
@@ -2964,8 +2964,8 @@ msgid "_View"
 msgstr "檢視(_V)"
 
 #: ../gui/data/packagemanager.ui.glade.h:169 ../modules/gui/repository.py:90
-msgid "e.g. https://pkg.omniosce.org/r151022/core"
-msgstr "例如 https://pkg.omniosce.org/r151022/core"
+msgid "e.g. https://pkg.omnios.org/r151022/core"
+msgstr "例如 https://pkg.omnios.org/r151022/core"
 
 #: ../gui/data/packagemanager.ui.h:170
 msgid "label"


### PR DESCRIPTION
In particular this makes the `pkgsrc` brand download from the correct site. I also added curl's `-L` option so that it can handle redirects in the future.