### PR TITLE
13613 ipkg platform.xml missing /dev/signalfd

### DIFF
--- a/src/brand/illumos/platform.xml
+++ b/src/brand/illumos/platform.xml
@@ -72,6 +72,7 @@
 	<device match="rlofi" />
 	<device match="rmt" />
 	<device match="sad/user" />
+	<device match="signalfd" />
 	<device match="smbsrv" />
 	<device match="svvslo0" />
 	<device match="svvslo1" />

--- a/src/brand/ipkg/platform.xml
+++ b/src/brand/ipkg/platform.xml
@@ -78,6 +78,7 @@
 	<device match="rlofi" />
 	<device match="rmt" />
 	<device match="sad/user" />
+	<device match="signalfd" />
 	<device match="smbsrv" />
 	<device match="svvslo0" />
 	<device match="svvslo1" />

--- a/src/brand/lipkg/platform.xml
+++ b/src/brand/lipkg/platform.xml
@@ -78,6 +78,7 @@
 	<device match="rlofi" />
 	<device match="rmt" />
 	<device match="sad/user" />
+	<device match="signalfd" />
 	<device match="smbsrv" />
 	<device match="svvslo0" />
 	<device match="svvslo1" />

--- a/src/brand/pkgsrc/platform.xml
+++ b/src/brand/pkgsrc/platform.xml
@@ -86,6 +86,7 @@
 	<device match="rlofi" />
 	<device match="rmt" />
 	<device match="sad/user" />
+	<device match="signalfd" />
 	<device match="smbsrv" />
 	<device match="svvslo0" />
 	<device match="svvslo1" />

--- a/src/brand/sparse/platform.xml
+++ b/src/brand/sparse/platform.xml
@@ -86,6 +86,7 @@
 	<device match="rlofi" />
 	<device match="rmt" />
 	<device match="sad/user" />
+	<device match="signalfd" />
 	<device match="smbsrv" />
 	<device match="svvslo0" />
 	<device match="svvslo1" />


### PR DESCRIPTION
This allows [signalfd(3C)](https://man.omnios.org/signalfd.3c) to work in a non-global zone.