### PR TITLE
ActionExecutionError should have an errno property

### DIFF
--- a/src/modules/client/api_errors.py
+++ b/src/modules/client/api_errors.py
@@ -1087,12 +1087,17 @@ class ActionExecutionError(ApiException):
                         use_errno = not details
                 self.use_errno = use_errno
 
+        @property
+        def errno(self):
+                if self.error and hasattr(self.error, "errno"):
+                        return self.error.errno
+                return None
+
         def __str__(self):
                 errno = ""
-                if self.use_errno and self.error and \
-                    hasattr(self.error, "errno"):
-                        errno = "[errno {0:d}: {1}]".format(self.error.errno,
-                            os.strerror(self.error.errno))
+                if self.use_errno and self.errno is not None:
+                        errno = "[errno {0:d}: {1}]".format(self.errno,
+                            os.strerror(self.errno))
 
                 details = self.details or ""
 

--- a/src/tests/api/t_pkg_api_install.py
+++ b/src/tests/api/t_pkg_api_install.py
@@ -1415,6 +1415,20 @@ class TestActionExecutionErrors(pkg5unittest.SingleDepotTestCase):
                 self.assertRaises(api_errors.ActionExecutionError,
                     self.__do_install, api_obj, [filesub10_pfmri])
 
+        def test_01_file_parent(self):
+
+                api_obj = self.image_create(self.rurl)
+
+                # File's parent directory replaced with a file
+                self.__do_install(api_obj, ['filesub', 'dir'])
+                dirpath = os.path.join(self.get_img_path(), "dir")
+                filepath = os.path.join(dirpath, "file")
+                os.unlink(filepath)
+                os.rmdir(dirpath)
+                open(dirpath, "wb").close()
+                self.assertRaises(api_errors.ActionExecutionError,
+                    self.__do_uninstall, api_obj, ['filesub'])
+
         def test_02_link(self):
                 """Verify that link install and removal works as expected when
                 link is already present before install or has been replaced


### PR DESCRIPTION
Through a series of unfortunate events, I got the IPS image for an `ipkg` zone into a broken state. When I tried to repair it, `pkg` said:

```
Removing old actions                         1/19460Action removal failed for 'usr/lib/python2.7/vendor-packages/setuptools-46.4.0-py2.7.egg-info/zip-safe' (pkg://omnios/library/python-2/setuptools-27):
 AttributeError: 'ActionExecutionError' object has no attribute 'errno'
pkg: An unexpected error happened during update: 'ActionExecutionError' object has no attribute 'errno'
zsh: exit 1     pkg -R /data/z
```

This turns out to be due to the fact that `action.remove_fsobj()` can raise an `OSError` exception, and it can also raise an `AttributeExecutionError` exception, particularly for unexpected failures. Callers of this method expect to be able to retrieve the `errno` property from the exception to see what caused the error.

This fixes, and adds a new test for the failure case I was seeing. Now I see:

```
Action removal failed for 'usr/lib/python2.7/vendor-packages/setuptools-46.4.0-py2.7.egg-info/SOURCES.txt' (pkg://omnios/library/python-2/setuptools-27):
 ActionExecutionError: [errno 20: Not a directory]

pkg: [errno 20: Not a directory]
```

which is more helpful.
The test failed when I added it, and passes with the change to the API error class.