### PR TITLE
Support for python 3.9.6 (r151038)

### DIFF
--- a/src/tests/api/t_manifest.py
+++ b/src/tests/api/t_manifest.py
@@ -23,6 +23,11 @@
 
 # Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
 
+from . import testutils
+if __name__ == "__main__":
+        testutils.setup_environment("../../../proto")
+import pkg5unittest
+
 import unittest
 import tempfile
 import os
@@ -41,11 +46,6 @@ import pkg.misc as misc
 import pkg.portable as portable
 import pkg.facet as facet
 import pkg.variant as variant
-
-# Set the path so that modules above can be found
-path_to_parent = os.path.join(os.path.dirname(__file__), "..")
-sys.path.insert(0, path_to_parent)
-import pkg5unittest
 
 class TestManifest(pkg5unittest.Pkg5TestCase):
 

--- a/src/tests/api/testutils.py
+++ b/src/tests/api/testutils.py
@@ -27,8 +27,9 @@ import os
 import sys
 
 # Set the path so that modules can be found
-path_to_parent = os.path.join(os.path.dirname(__file__), "..")
-sys.path.insert(0, path_to_parent)
+path_to_parent = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if path_to_parent not in sys.path:
+        sys.path.insert(0, path_to_parent)
 
 import pkg5testenv
 

--- a/src/tests/cli/testutils.py
+++ b/src/tests/cli/testutils.py
@@ -27,8 +27,9 @@ import os
 import sys
 
 # Set the path so that modules can be found
-path_to_parent = os.path.join(os.path.dirname(__file__), "..")
-sys.path.insert(0, path_to_parent)
+path_to_parent = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if path_to_parent not in sys.path:
+        sys.path.insert(0, path_to_parent)
 
 import pkg5testenv
 

--- a/src/tests/run.py
+++ b/src/tests/run.py
@@ -591,6 +591,23 @@ if __name__ == "__main__":
                         os.chown(".coverage", uid, gid)
                 except EnvironmentError:
                         pass
+
+        # The tree likely contains python cache objects owned by root, if a
+        # true test run was performed. Adjust the ownership to match the
+        # test directory so they can be easily removed.
+        try:
+                uid, gid = os.stat(".")[4:6]
+                for dir in ['.', '../../proto']:
+                        for root, dirs, files in os.walk(dir):
+                                if os.path.basename(root) != '__pycache__':
+                                        continue
+                                os.chown(root, uid, gid);
+                                for name in [*dirs, *files]:
+                                        os.chown(os.path.join(root, name),
+                                            uid, gid)
+        except EnvironmentError:
+                pass
+
         sys.exit(exitval)
 
 # Vim hints

--- a/src/tests/testsuite/testutils.py
+++ b/src/tests/testsuite/testutils.py
@@ -27,8 +27,9 @@ import os
 import sys
 
 # Set the path so that modules can be found
-path_to_parent = os.path.join(os.path.dirname(__file__), "..")
-sys.path.insert(0, path_to_parent)
+path_to_parent = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if path_to_parent not in sys.path:
+        sys.path.insert(0, path_to_parent)
 
 import pkg5testenv
 


### PR DESCRIPTION
With these changes, the testsuite passes with Python 3.9.5 and Python 3.9.6.