### PR TITLE
bhyve always requires PCI functions to be in order

### DIFF
--- a/src/brand/bhyve/boot
+++ b/src/brand/bhyve/boot
@@ -370,8 +370,8 @@ for dev in xmlroot.findall('./attr[@name]'):
     k = int(m.group(1))
     if ppt == 0:
         args.append('-S')
-    args.extend(['-s', '{0}:{1},passthru,/dev/ppt{1}'.format(
-        PPT_SLOT, k)])
+    args.extend(['-s', '{0}:{1},passthru,/dev/ppt{2}'.format(
+        PPT_SLOT, ppt, k)])
     ppt += 1
 
 # RNG


### PR DESCRIPTION
This fixes https://github.com/omniosorg/pkg5/issues/331

Bhyve expects the function to be filled starting at 0, you cannot have something in function 1 if there is no function 0. Currently the brand takes the number of the ppt device as the function, that will result in only ppt0 working unless you pass all of them to the same zone.

## Before
### /etc/bhyve.cfg
```
#
# Generated from zone configuration
#
acpi_tables=false
memory.size=1G
memory.wired=true
x86.strictmsr=true
x86.vmexit_on_hlt=true
uuid=17f57668-b2b9-c188-dac6-e44919140731
smbios.manufacturer=OmniOS
smbios.product=OmniOS HVM
smbios.version=1.0
smbios.serial=17f57668-b2b9-c188-dac6-e44919140731
smbios.sku=001
smbios.family=Virtual Machine
cpus=1
sockets=1
cores=1
threads=1
lpc.bootrom=/usr/share/bhyve/firmware/BHYVE_RELEASE.fd
lpc.com1.path=/dev/zconsole
pci.0.0.0.device=hostbridge
pci.0.0.0.model=i440fx
pci.0.1.0.device=lpc
pci.0.4.0.device=nvme
pci.0.4.0.path=/dev/zvol/rdsk/rpool/vms/rcon2/disk0
pci.0.6.0.device=virtio-net
pci.0.6.0.backend=dlpi
pci.0.6.0.vnic=rcon2
pci.0.9.1.device=passthru
pci.0.9.1.path=/dev/ppt1
pci.0.10.0.device=virtio-rnd
name=rcon2
```
### pciconf -lv (FreeBSD VM)
```
hostb0@pci0:0:0:0:      class=0x060000 rev=0x00 hdr=0x00 vendor=0x8086 device=0x1237 subvendor=0x0000 subdevice=0x0000
    vendor     = 'Intel Corporation'
    device     = '440FX - 82441FX PMC [Natoma]'
    class      = bridge
    subclass   = HOST-PCI
isab0@pci0:0:1:0:       class=0x060100 rev=0x00 hdr=0x00 vendor=0x8086 device=0x7000 subvendor=0x0000 subdevice=0x0000
    vendor     = 'Intel Corporation'
    device     = '82371SB PIIX3 ISA [Natoma/Triton II]'
    class      = bridge
    subclass   = PCI-ISA
nvme0@pci0:0:4:0:       class=0x010802 rev=0x00 hdr=0x00 vendor=0xfb5d device=0x0a0a subvendor=0x0000 subdevice=0x0000
    class      = mass storage
    subclass   = NVM
virtio_pci0@pci0:0:6:0: class=0x020000 rev=0x00 hdr=0x00 vendor=0x1af4 device=0x1000 subvendor=0x1af4 subdevice=0x0001
    vendor     = 'Red Hat, Inc.'
    device     = 'Virtio network device'
    class      = network
    subclass   = ethernet
virtio_pci1@pci0:0:10:0:        class=0x100000 rev=0x00 hdr=0x00 vendor=0x1af4 device=0x1005 subvendor=0x1af4 subdevice=0x0004
    vendor     = 'Red Hat, Inc.'
    device     = 'Virtio RNG'
    class      = encrypt/decrypt
    subclass   = network/computer crypto
```

## after
### /etc/bhyve.cfg
```
#
# Generated from zone configuration
#
acpi_tables=false
memory.size=1G
memory.wired=true
x86.strictmsr=true
x86.vmexit_on_hlt=true
uuid=17f57668-b2b9-c188-dac6-e44919140731
smbios.manufacturer=OmniOS
smbios.product=OmniOS HVM
smbios.version=1.0
smbios.serial=17f57668-b2b9-c188-dac6-e44919140731
smbios.sku=001
smbios.family=Virtual Machine
cpus=1
sockets=1
cores=1
threads=1
lpc.bootrom=/usr/share/bhyve/firmware/BHYVE_RELEASE.fd
lpc.com1.path=/dev/zconsole
pci.0.0.0.device=hostbridge
pci.0.0.0.model=i440fx
pci.0.1.0.device=lpc
pci.0.4.0.device=nvme
pci.0.4.0.path=/dev/zvol/rdsk/rpool/vms/rcon2/disk0
pci.0.6.0.device=virtio-net
pci.0.6.0.backend=dlpi
pci.0.6.0.vnic=rcon2
pci.0.9.0.device=passthru
pci.0.9.0.path=/dev/ppt1
pci.0.10.0.device=virtio-rnd
name=rcon2
```

### pciconf -lv (FreeBSD VM)
```
hostb0@pci0:0:0:0:      class=0x060000 rev=0x00 hdr=0x00 vendor=0x8086 device=0x1237 subvendor=0x0000 subdevice=0x0000
    vendor     = 'Intel Corporation'
    device     = '440FX - 82441FX PMC [Natoma]'
    class      = bridge
    subclass   = HOST-PCI
isab0@pci0:0:1:0:       class=0x060100 rev=0x00 hdr=0x00 vendor=0x8086 device=0x7000 subvendor=0x0000 subdevice=0x0000
    vendor     = 'Intel Corporation'
    device     = '82371SB PIIX3 ISA [Natoma/Triton II]'
    class      = bridge
    subclass   = PCI-ISA
nvme0@pci0:0:4:0:       class=0x010802 rev=0x00 hdr=0x00 vendor=0xfb5d device=0x0a0a subvendor=0x0000 subdevice=0x0000
    class      = mass storage
    subclass   = NVM
virtio_pci0@pci0:0:6:0: class=0x020000 rev=0x00 hdr=0x00 vendor=0x1af4 device=0x1000 subvendor=0x1af4 subdevice=0x0001
    vendor     = 'Red Hat, Inc.'
    device     = 'Virtio network device'
    class      = network
    subclass   = ethernet
xhci0@pci0:0:9:0:       class=0x0c0330 rev=0x02 hdr=0x00 vendor=0x1912 device=0x0015 subvendor=0x1912 subdevice=0x0015
    vendor     = 'Renesas Technology Corp.'
    device     = 'uPD720202 USB 3.0 Host Controller'
    class      = serial bus
    subclass   = USB
virtio_pci1@pci0:0:10:0:        class=0x100000 rev=0x00 hdr=0x00 vendor=0x1af4 device=0x1005 subvendor=0x1af4 subdevice=0x0004
    vendor     = 'Red Hat, Inc.'
    device     = 'Virtio RNG'
    class      = encrypt/decrypt
    subclass   = network/computer crypto
```