### PR TITLE
Support preserve=true for link actions

### DIFF
--- a/src/man/pkg.5
+++ b/src/man/pkg.5
@@ -2,7 +2,7 @@
 .\" Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
 .\" Copyright (c) 2012, OmniTI Computer Consulting, Inc. All rights reserved.
 .\" Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
-.Dd February 26, 2021
+.Dd july 17, 2021
 .Dt PKG 5
 .Os OmniOS
 .Sh NAME
@@ -793,6 +793,15 @@ action's key attribute.
 .It Sy target
 The target of the symbolic link.
 The file system object to which the link resolves.
+.It Sy preserve
+Specifies when and how links are preserved during package operations.
+.Pp
+When a package is modified, if a link delivered by the package has a
+.Sy preserve
+attribute set to
+.Sy true
+and that link has been removed or modified in the image, then the packaged
+link will not be installed.
 .It Sy mediator
 Specifies the entry in the mediation namespace shared by all path names
 participating in a given mediation group

--- a/src/modules/actions/generic.py
+++ b/src/modules/actions/generic.py
@@ -967,24 +967,27 @@ class Action(object):
                                 return "Unknown (0x{0:x})".format(ftype)
 
                 mode = owner = group = None
-                if "mode" in self.attrs:
-                        mode = int(self.attrs["mode"], 8)
-                if "owner" in self.attrs:
-                        owner = self.attrs["owner"]
-                        try:
-                                owner = img.get_user_by_name(owner)
-                        except KeyError:
-                                errors.append(_("owner: {0} is unknown").format(
-                                    owner))
-                                owner = None
-                if "group" in self.attrs:
-                        group = self.attrs["group"]
-                        try:
-                                group = img.get_group_by_name(group)
-                        except KeyError:
-                                errors.append(_("group: {0} is unknown ").format(
-                                    group))
-                                group = None
+                if ftype != stat.S_IFLNK:
+                        if "mode" in self.attrs:
+                                mode = int(self.attrs["mode"], 8)
+                        if "owner" in self.attrs:
+                                owner = self.attrs["owner"]
+                                try:
+                                        owner = img.get_user_by_name(owner)
+                                except KeyError:
+                                        errors.append(
+                                            _("owner: {0} is unknown").format(
+                                            owner))
+                                        owner = None
+                        if "group" in self.attrs:
+                                group = self.attrs["group"]
+                                try:
+                                        group = img.get_group_by_name(group)
+                                except KeyError:
+                                        errors.append(
+                                            _("group: {0} is unknown ").format(
+                                            group))
+                                        group = None
 
                 path = self.get_installed_path(img.get_root())
 


### PR DESCRIPTION
This is useful for packages that deliver their configuration including a set of symbolic links that are used to enable features, for example:

```
# ls -l /etc/opt/ooce/freeradius/mods-enabled
total 30
lrwxrwxrwx   1 root     root          24 Jul 17 10:31 always -> ../mods-available/always
lrwxrwxrwx   1 root     root          29 Jul 17 10:31 attr_filter -> ../mods-available/attr_filter
```

To disable a feature, the administrator just removes the symbolic link. Unfortunately, `pkg` will restore it on `pkg fix` or on any `pkg update` that modifies that action.

This change adds support for `preserve=true` on links in which case they will be left alone if they have been deleted or changed between updates. `pkg verify` will also not report these as errors.

There's also a change in here to fix a problem caused with `link` actions that have `owner`, `group` or `mode` set on them. Those are not special attributes for a `link` but they were being checked against the file properties of the link target, resulting in erroneous output from `pkg verify`.
