### PR TITLE
Skip tests which will always fail on OmniOS

### DIFF
--- a/src/tests/baseline3.txt
+++ b/src/tests/baseline3.txt
@@ -1,5 +1,0 @@
-cli.t_pkg_install.py TestPkgInstallApache.test_corrupt_web_cache|error
-cli.t_pkg_install.py TestPkgInstallApache.test_granular_proxy|error
-cli.t_pkgrecv.py TestPkgrecvHTTPS.test_01_basics|error
-cli.t_pkgrepo.py TestPkgrepoHTTPS.test_01_basics|error
-cli.t_pkgsend.py TestPkgsendHTTPS.test_01_basics|error

--- a/src/tests/run.py
+++ b/src/tests/run.py
@@ -305,7 +305,9 @@ def find_tests(testdir, testpats, startatpat=False, output=OUTPUT_DOTS,
                         # have Apache-backed repos or depots
                         if cname in ['TestSysrepo', 'TestHTTPS',
                             'TestBasicSysrepoCli', 'TestDetailedSysrepoCli',
-                            'TestHttpDepot', 'TestHttpsDepot']:
+                            'TestHttpDepot', 'TestHttpsDepot',
+                            'TestPkgInstallApache', 'TestPkgrecvHTTPS',
+                            'TestPkgrepoHTTPS', 'TestPkgsendHTTPS']:
                                 continue
 
                         for attrname in dir(classobj):


### PR DESCRIPTION
We don't support the Apache integration for IPS repos and so these tests always fail due to apache not being available. Up to now they have just been listed in the baseline file but it's better to skip running those test classes completely:

Before
```
ERROR: cli.t_pkg_install.py TestPkgInstallApache.test_corrupt_web_cache
ERROR: cli.t_pkg_install.py TestPkgInstallApache.test_granular_proxy
ERROR: cli.t_pkgrecv.py TestPkgrecvHTTPS.test_01_basics
ERROR: cli.t_pkgrepo.py TestPkgrepoHTTPS.test_01_basics
ERROR: cli.t_pkgsend.py TestPkgsendHTTPS.test_01_basics

# Ran 1067 tests in 1718.207s - skipped 1 tests.

======================================================================
BASELINE MATCH
======================================================================
```
After
```
# Ran 1062 tests in 1553.648s - skipped 1 tests.

======================================================================
BASELINE MATCH
======================================================================
```