### PR TITLE
#338 bhyve brand should set promisc-filtered according to the promiscphys nic property

### DIFF
--- a/src/brand/bhyve/boot
+++ b/src/brand/bhyve/boot
@@ -212,6 +212,9 @@ def build_devlist(type, maxval, plain=True):
 
     return sorted(devlist.items())
 
+def bool(s):
+    return s in ['true', 'yes', 'on', '1']
+
 ##############################################################################
 
 for tag in opts.keys():
@@ -333,6 +336,7 @@ for i, v in build_devlist('disk', 16):
 # Network
 
 i = 0
+promisc_filtered_nics = {}
 for f in xmlroot.findall('./network[@physical]'):
     ifname = f.get('physical').strip()
 
@@ -343,6 +347,8 @@ for f in xmlroot.findall('./network[@physical]'):
         if k == "netif":
             netif = v
         else:
+            if k == "promiscphys":
+                promisc_filtered_nics[ifname] = 'off' if bool(v) else 'on'
             net_extra += ',{}={}'.format(k, v)
 
     args.extend([
@@ -350,6 +356,18 @@ for f in xmlroot.findall('./network[@physical]'):
         .format(NET_SLOT, i, netif, ifname, net_extra)
     ])
     i += 1
+
+for nic, promisc in promisc_filtered_nics.items():
+    dladm_args = [
+        '/usr/sbin/dladm', 'set-linkprop',
+        '-p', f'promisc-filtered={promisc}',
+        nic,
+    ]
+
+    logging.debug(f'Setting promisc-filtered for {nic} to {promisc}')
+    p = subprocess.run(dladm_args, capture_output=True, text=True)
+    if p.returncode > 0:
+        fatal(f'Could set promisc-filtered for {nic}: {p.stderr}')
 
 # VNC
 


### PR DESCRIPTION
I'm not 100% happy with this, but this seems to work rather well.

The nice thing is that it does what I as user would expect, when I set promiscphys=true I will get all traffic on the physical interface (well, ideally I'd get something that matches vmware but that's a whole other hill to climb).

Downside is that it's not nicely contained to bhyve brand only, if we push promiscphys as a net property for say a lipkg brand zone it will set promisc-filtered accordingly, although useful I guess, it not really my intention here and I have not found a way to filter out what brand we are in the shared code :(

Also I'm not good with awk, I'm sure that bit can be improved too.