### PR TITLE
Enforce minimum system/zones version for the bhyve brand (r151038)

### DIFF
--- a/src/pkg/manifests/system:zones:brand:bhyve.p5m
+++ b/src/pkg/manifests/system:zones:brand:bhyve.p5m
@@ -37,3 +37,7 @@ license lic_CDDL license=lic_CDDL
 depend type=require fmri=system/bhyve
 depend type=require fmri=system/zones/brand/ipkg@$(PKGVERS)
 depend type=require fmri=system/zones/brand/sparse@$(PKGVERS)
+# The bhyve brand needs at least the following version of system/zones
+# to support the attributes to control zone init behaviour and
+# security flags.
+depend type=require fmri=system/zones@$(PKGVERS):20210530T143222Z


### PR DESCRIPTION
In the first reboot update for r151038, the system/zones package was updated to add new features which became necessary for the bhyve brand. However, the dependency was not added to the package data so it is possible to install the bhyve brand on the release version of r151038, where it does not operate.
This doesn't need to go into the master branch since the next release version will be self consistent.