### PR TITLE
Add support for 9p filesystem sharing

### DIFF
--- a/src/brand/bhyve/boot
+++ b/src/brand/bhyve/boot
@@ -91,6 +91,7 @@ CDROM_SLOT2     = 7
 DISK_SLOT2      = 8
 PPT_SLOT        = 9
 RNG_SLOT        = 10
+VIRTFS_SLOT     = 11
 CINIT_SLOT      = 29
 VNC_SLOT        = 30
 LPC_SLOT_WIN    = 31
@@ -207,13 +208,16 @@ def diskpath(arg):
         return arg
     return '/dev/zvol/rdsk/{0}'.format(arg)
 
+def findattr(rex):
+    for dev in xmlroot.findall('./attr[@name]'):
+        if m := re.search(rex, dev.get('name').strip()):
+            yield dev, m
+
 # Look for attributes of the form <type>N (and <type> if plain is True) and
 # generate a list.
 def build_devlist(type, maxval, plain=True):
     devlist = {}
-    for dev in xmlroot.findall('./attr[@name]'):
-        m = re.search(rf'^{type}(\d+)$', dev.get('name').strip())
-        if not m: continue
+    for dev, m in findattr(rf'^{type}(\d+)$'):
         k = int(m.group(1))
         if k in devlist:
             fatal(f'{type}{k} appears more than once in configuration')
@@ -578,6 +582,21 @@ if len(pptassign) > 0:
     for i, v in sorted(pptassign.items()):
         args.extend(['-s', '{0}:{1},passthru,/dev/{2}'.format(
             PPT_SLOT, i, v)])
+
+# virtio-9p devices
+
+for i, v in build_devlist('virtfs', 8):
+    # Expect <sharename>,<path>[,ro]
+    arr = v.split(',')
+    vfsopts = ''
+    if len(arr) == 3:
+        if arr[2] != 'ro':
+            fatal(f'Unknown virtfs attribute {arr[2]}')
+        vfsopts = ',ro'
+    elif len(arr) != 2:
+        fatal(f'Bad virtfs specification: {v}')
+    args.extend(['-s', '{0}:{1},virtio-9p,{2}={3}{4}'.format(
+        VIRTFS_SLOT, i, arr[0], arr[1], vfsopts)])
 
 # RNG
 

--- a/src/brand/bhyve/config.xml
+++ b/src/brand/bhyve/config.xml
@@ -56,6 +56,7 @@
 	<privilege set="default" name="proc_clock_highres" />
 	<privilege set="default" name="sys_admin" />
 	<privilege set="default" name="sys_mount" />
+
 	<!--
 		The following privilege is given to allow reading backing
 		files (for example .iso images) whose permission bits or ACL
@@ -65,6 +66,20 @@
 		be able to read it.
 	-->
 	<privilege set="default" name="file_dac_read" />
+
+	<!--
+		The following privileges are necessary for virtio-9p. The
+		first for read-only mounts (dac_read is also necessary but
+		asserted above), and the remainder for read-write.
+	-->
+	<privilege set="default" name="file_dac_read" />
+	<privilege set="default" name="file_dac_search" />
+	<privilege set="default" name="file_chown" />
+	<privilege set="default" name="file_chown_self" />
+	<privilege set="default" name="file_write" />
+	<privilege set="default" name="file_dac_write" />
+	<privilege set="default" name="file_owner" />
+	<privilege set="default" name="file_link_any" />
 
 	<privilege set="prohibited" name="dtrace_kernel" />
 	<privilege set="prohibited" name="proc_zone" />

--- a/src/man/bhyve.5
+++ b/src/man/bhyve.5
@@ -395,6 +395,30 @@ must equal the product of the other parameters.
 .Pp
 The maximum supported number of virtual CPUs is
 .Sy 32 .
+.It Xo
+.Sy virtfs Ns Op Ar N
+.Sm off
+.Ar sharename \&,
+.Ar path
+.Op Cm ,ro
+.Sm on
+.Xc
+.Pp
+Share a filesystem to the guest using Virtio 9p (VirtFS).
+The specified
+.Ar path
+is presented over PCI as a share named
+.Ar sharename .
+The optional
+.Cm ro
+option configures the share as read-only.
+The filesystem path being shared must also be mapped into the zone, using
+either a delegated dataset or a loopback
+.Pq lofs
+mount.
+See the
+.Sx EXAMPLES
+section below.
 .It Sy vga Ar off Ns | Ns Ar on Ns | Ns Ar io
 .Pp
 Specify the type of VGA emulation to use when the framebuffer and VNC server
@@ -535,7 +559,52 @@ add attr
     set value=/rpool/iso/debian-9.4.0-amd64-netinst.iso
 end
 .Ed
-.sp
+.Pp
+The following example shows how to share a delegated dataset called
+.Pa rpool/datavol
+to a guest using VirtFS.
+This assumes that the mountpoint attribute on
+.Pa rpool/datavol
+is set to
+.Pa /datavol .
+This could have been done, for example, by creating the dataset with:
+.Pp
+.Dl zfs create -o mountpoint=/datavol -o zoned=on rpool/datavol
+.Pp
+Setting the
+.Sy mountpoint
+and
+.Sy zoned
+attributes at the same time prevents the filesystem from ever being mounted in
+the global zone.
+.Bd -literal -offset indent
+add dataset
+    set name=rpool/datavol
+end
+add attr
+    set name=virtfs0
+    set type=string
+    set value=datavol,/datavol
+end
+.Ed
+.Pp
+and to share the global zone filesystem
+.Pa /data/websites
+read-only to the guest, add:
+.Bd -literal -offset indent
+add fs
+    set dir="/data/websites"
+    set special="/data/websites"
+    set type="lofs"
+    add options ro
+    add options nodevices
+end
+add attr
+    set name=virtfs1
+    set type=string
+    set value=websites,/data/websites,ro
+end
+.Ed
 .Sh SEE ALSO
 .Xr mdb 1 ,
 .Xr proc 1 ,

--- a/src/man/bhyve.5
+++ b/src/man/bhyve.5
@@ -12,7 +12,7 @@
 .\" Copyright 2016, OmniTI Computer Consulting, Inc. All Rights Reserved.
 .\" Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
 .\"
-.Dd August 13, 2021
+.Dd September 11, 2021
 .Dt BHYVE 5
 .Os OmniOS
 .Sh NAME
@@ -415,6 +415,8 @@ result in I/O port queries and fail to boot if I/O decode is disabled.
 .Sm off
 .Ar on
 |
+.Ar wait
+|
 .Ar off
 |
 .Ar options
@@ -431,6 +433,12 @@ An alias for
 which creates the VNC socket within
 .Pa /tmp
 inside the zone.
+.It Sy wait
+An alias for
+.Sy wait,unix=/tmp/vm.vnc
+which is identical to
+.Sy on
+except that the zone boot is halted until a VNC connection is established.
 .It Sy off
 Disable the framebuffer.
 This is the same as omitting the
@@ -440,12 +448,14 @@ attribute.
 Sets up a VNC server on a UNIX socket at the specified
 .Ar path .
 Note that this path is relative to the zone root.
-.It Sy w
+.It Sy w Ns = Ns Ar pixels
 Specifies the horizontal screen resolution
 .Pq default: 1024, max: 1920
-.It Sy h
+.It Sy h Ns = Ns Ar pixels
 Specifies the vertical screen resolution
 .Pq default: 768, max: 1200
+.It Sy wait
+Pause boot until a VNC connection is established.
 .El
 .Pp
 Multiple options can be provided, separated by commas.


### PR DESCRIPTION
Also fixes https://github.com/omniosorg/pkg5/issues/353

@sjorge

```
# zonecfg -z bhyvetest info
fs:
        dir: /data/af/iso
        special: /data/af/iso
        raw not specified
        type: lofs
        options: [nodevices]
attr:
        name: 9p-bob
        type: string
        value: /data/af/iso
```

```
root@bhyvetest:/bob# uname -a
Linux bhyvetest 5.10.0-8-amd64 #1 SMP Debian 5.10.46-4 (2021-08-03) x86_64 GNU/Linux
root@bhyvetest:~# mkdir /bob
root@bhyvetest:~# 9mount -su 'virtio!bob' /bob
[  289.460147] FS-Cache: Loaded
[  289.465385] 9p: Installing v9fs 9p2000 file system support
[  289.466975] FS-Cache: Netfs '9p' registered for caching
root@bhyvetest:~# ls /bob
debian-11-generic-amd64-20210814-734.raw  ubuntu-20.04.2-live-server-amd64.iso
f                                         zadm
```

```
# ptree -z bhyvetest
18232  zsched
  18317  bhyve-bhyvetest -k /etc/bhyve.cfg

# ppriv -S 18317
18317:  bhyve-bhyvetest -k /etc/bhyve.cfg
flags = PRIV_DEBUG|PRIV_AWARE
        E: file_chown,file_chown_self,file_dac_read,file_dac_search,file_dac_write,file_link_any,file_owner,file_read,file_write,proc_clock_highres
        I: basic
        P: file_chown,file_chown_self,file_dac_read,file_dac_search,file_dac_write,file_link_any,file_owner,file_read,file_write,proc_clock_highres
        L: file_chown,file_chown_self,file_dac_read,file_dac_search,file_dac_write,file_link_any,file_owner,file_read,file_write,proc_clock_highres
```