### PR TITLE
Add curlverbose debug option

### DIFF
--- a/src/modules/client/transport/engine.py
+++ b/src/modules/client/transport/engine.py
@@ -791,6 +791,9 @@ class CurlTransportEngine(TransportEngine):
                 # Set nosignal, so timeouts don't crash client
                 hdl.setopt(pycurl.NOSIGNAL, 1)
 
+                if DebugValues.get("curlverbose", False):
+                        hdl.setopt(pycurl.VERBOSE, 1)
+
                 # Set connect timeout.  Its value is defined in global_settings.
                 hdl.setopt(pycurl.CONNECTTIMEOUT,
                     global_settings.PKG_CLIENT_CONNECT_TIMEOUT)


### PR DESCRIPTION
Without the new option:
```
bloody:pkg5:curlverbose% pfexec python3 =pkg refresh
```

and with:

```
bloody:pkg5:curlverbose% pfexec python3 =pkg -Dcurlverbose=1 refresh
Refreshing catalog 1/2 extra.omnios*   Trying 129.132.2.8:443...
* Connected to pkg.omnios.org (129.132.2.8) port 443 (#0)
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: none
*  CApath: /etc/ssl/certs
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
* ALPN, server accepted to use http/1.1
* Server certificate:
*  subject: CN=pkg.omnios.org
*  start date: Oct  8 08:13:24 2021 GMT
*  expire date: Jan  6 08:13:23 2022 GMT
*  subjectAltName: host "pkg.omnios.org" matched cert's "pkg.omnios.org"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
> GET /bloody/core/versions/0/ HTTP/1.1
...
```