### PR TITLE
image-create attempts to remove directories above the target

### DIFF
--- a/src/modules/client/image.py
+++ b/src/modules/client/image.py
@@ -1012,7 +1012,7 @@ in the environment or by setting simulate_cmdpath in DebugValues.""")
                                 atexit.register(shutil.rmtree,
                                     self.__write_cache_dir, ignore_errors=True)
                 else:
-                        os.removedirs(self._incoming_cache_dir)
+                        os.rmdir(self._incoming_cache_dir)
 
                 # Forcibly discard image catalogs so they can be re-loaded
                 # from the new location if they are already loaded.  This


### PR DESCRIPTION
As reported by @jclulow, when creating an image, `pkg5` will recursively attempt to delete the parent directories of the target path.

```

% mkdir -p /tmp/blah/blah/blah
% truss -t rmdir,mkdir  pkg image-create /tmp/blah/blah/blah/root

mkdir("/tmp/blah/blah/blah/root", 0777)		= 0
mkdir("/tmp/blah/blah/blah/root/.org.opensolaris,pkg", 0777) = 0
mkdir("/tmp/blah/blah/blah/root/.org.opensolaris,pkg/cache", 0777) = 0
mkdir("/tmp/blah/blah/blah/root/.org.opensolaris,pkg/cache/incoming-6094", 0777) = 0
rmdir("/tmp/blah/blah/blah/root/.org.opensolaris,pkg/cache/incoming-6094") = 0
rmdir("/tmp/blah/blah/blah/root/.org.opensolaris,pkg/cache") = 0
rmdir("/tmp/blah/blah/blah/root/.org.opensolaris,pkg") = 0
rmdir("/tmp/blah/blah/blah/root")		= 0
rmdir("/tmp/blah/blah/blah")			= 0
rmdir("/tmp/blah/blah")				= 0
rmdir("/tmp/blah")				= 0
rmdir("/tmp")					Err#16 EBUSY
mkdir("/tmp/blah", 0777)			= 0
mkdir("/tmp/blah/blah", 0777)			= 0
mkdir("/tmp/blah/blah/blah", 0777)		= 0
mkdir("/tmp/blah/blah/blah/root", 0777)		= 0
```

```
bloody% pfexec dtrace -n 'syscall::rmdir:entry {trace(copyinstr(arg0));jstack()}' -c ' pkg image-create /tmp/blah/blah/blah/root'
 
  5  17104                      rmdir:entry   /tmp/blah/blah/blah
              libc.so.1`_syscall6+0x1b
              libpython3.10.so.1.0`os_rmdir+0x282
                [ /usr/lib/python3.10/os.py:245 (removedirs) ]
                [ /usr/lib/python3.10/vendor-packages/pkg/client/image.py:5392 (__set_dirs) ]
                [ /usr/lib/python3.10/vendor-packages/pkg/client/image.py:711 (__init__) ]
                [ /usr/lib/python3.10/vendor-packages/pkg/client/api.py:6749 (image_create) ]
                [ /usr/bin/pkg:6284 (image_create) ]
                [ /usr/bin/pkg:8042 (main_func) ]
                [ /usr/bin/pkg:6191 (handle_errors) ]
                [ /usr/bin/pkg:8182 (<module>) ]
```
