### PR TITLE
bhyve: also check inside zoneroot for bootrom

### DIFF
--- a/src/brand/bhyve/boot.py
+++ b/src/brand/bhyve/boot.py
@@ -503,7 +503,8 @@ if bootrom.find('/') == -1:
     bootrom = f'/usr/share/bhyve/firmware/{bootrom}'
 if not bootrom.endswith('.fd'):
     bootrom += '.fd'
-if not os.path.isfile(bootrom):
+# NOTE: boot runs in gz context, also check inside the zoneroot
+if not os.path.isfile(bootrom) and not os.path.isfile(f'{zoneroot}/{bootrom}'):
     fatal(f'bootrom {opts["bootrom"]} not found.')
 logging.debug(f'Final bootrom: {bootrom}')
 

--- a/src/brand/bhyve/boot.py
+++ b/src/brand/bhyve/boot.py
@@ -499,13 +499,12 @@ if opts['bootorder'].startswith('c') and opts['type'] != 'windows':
 
 # Bootrom
 bootrom = opts['bootrom']
-if bootrom.find('/') == -1:
+if not os.path.isabs(bootrom):
     bootrom = f'/usr/share/bhyve/firmware/{bootrom}'
-if not bootrom.endswith('.fd'):
-    bootrom += '.fd'
-# NOTE: boot runs in gz context, also check inside the zoneroot
-if not os.path.isfile(bootrom) and not os.path.isfile(f'{zoneroot}/{bootrom}'):
-    fatal(f'bootrom {opts["bootrom"]} not found.')
+    if not bootrom.endswith('.fd'):
+        bootrom += '.fd'
+    if not os.path.isfile(bootrom):
+        fatal(f'bootrom {opts["bootrom"]} not found.')
 logging.debug(f'Final bootrom: {bootrom}')
 
 # UUID


### PR DESCRIPTION
While testing a bootrom I copied it to `/zones/<name>/root/var/<bootrom>.fd`, thinking this should be sufficient for bhyve to be able to use it.

However, boot.py does some validation and when it is run it is only checking the global zone, resulting in it complaining about a missing bootrom.

The old check is fine for bootroms in `/usr/share/bhyve/firmware` as this path gets mounted inside the zoneroot once booted. -> path exists both in the gz and zoneroot == check OK.

In my case where the bootrom was located in the zoneroot for the zone I was testing with. The path inside the zone and global zone is not the same, so the check failed.

I've updated the check to with the zoneroot prepended, so boot.py checks both `/var/BHYVE_RELEASE-202111.fd` (fails) and `/zones/proteus/root/var/BHYVE_RELEASE-202111.fd` (succeeds). The bhyve process inside the zone uses `/var/BHYVE_RELEASE-202111.fd`  and is also happy as this path exists.