### PR TITLE
Support having disks with differing emulation

### DIFF
--- a/src/brand/bhyve/boot.py
+++ b/src/brand/bhyve/boot.py
@@ -617,14 +617,23 @@ except:
 # Additional Disks
 
 for i, v in build_devlist('disk', 16):
+    if (vv := xmlroot.find(f'./attr[@name="diskif{i}"]')) is not None:
+        diskif = vv.get('value')
+        try:
+            diskif = aliases['diskif'][diskif]
+        except KeyError:
+            pass
+    else:
+        diskif = opts['diskif']
+
     if i < 8:
         args.extend([
-            '-s', '{0}:{1},{2},{3}'.format(DISK_SLOT, i, opts['diskif'],
+            '-s', '{0}:{1},{2},{3}'.format(DISK_SLOT, i, diskif,
             diskpath(v))
         ])
     else:
         args.extend([
-            '-s', '{0}:{1},{2},{3}'.format(DISK_SLOT2, i - 8, opts['diskif'],
+            '-s', '{0}:{1},{2},{3}'.format(DISK_SLOT2, i - 8, diskif,
             diskpath(v))
         ])
 

--- a/src/brand/bhyve/boot.py
+++ b/src/brand/bhyve/boot.py
@@ -75,7 +75,7 @@ aliases = {
     },
     'vnc': {
         'on':   'unix=/tmp/vm.vnc',
-        'wait': 'wait,unix=/tmp/vm.vnc',
+        'wait': 'unix=/tmp/vm.vnc,wait',
     },
     'bootrom': {
         # These old firmware files were present before r151035. Provide aliases
@@ -204,6 +204,15 @@ def boolv(s, var, ignore=False):
         fatal(f'Invalid value {s} for boolean variable {var}')
     return None
 
+def file_or_string(f):
+    if os.path.isabs(f) and os.path.isfile(f):
+        try:
+            with open(f) as fh:
+                f = fh.read()
+        except Exception as e:
+            fatal(f'Could not read from {f}: {e}')
+    return f.strip()
+
 def parseopt(tag):
     global opts, xmlroot
     try:
@@ -222,6 +231,27 @@ def parseopt(tag):
                 pass
     except:
         pass
+
+def expandopts(opt):
+    """ Expand a comma-separated option string out into a dictionary.
+        For example:
+            on,password=fred,wait,w=1234
+        becomes:
+            {'on': '', 'password': 'fred', 'wait': '', 'w': '1234'}
+    """
+    return {
+        k: v
+        for (k, v, *_)
+        in [
+            (o + '=').split('=')
+            for o in opt.split(',')
+        ]
+    }
+
+def collapseopts(opts):
+    """ The reverse of expandopts. Convert a dictionary back into an option
+        string. """
+    return ','.join([f'{k}={v}'.rstrip('=') for k, v in opts.items()])
 
 def writecfg(fh, arg):
     if testmode:
@@ -307,15 +337,6 @@ def build_cloudinit_image(uuid, src):
         'hostname':         name,
         'disable_root':     False,
     }
-
-    def file_or_string(f):
-        if os.path.isabs(f) and os.path.isfile(f):
-            try:
-                with open(f) as fh:
-                    f = fh.read()
-            except Exception as e:
-                fatal(f'Could not read from {f}: {e}')
-        return f.strip()
 
     if (v := xmlroot.find('./attr[@name="password"]')) is not None:
         user_data['password'] = file_or_string(v.get('value'))
@@ -681,6 +702,29 @@ v = boolv(opts['vnc'], 'vnc', ignore=True)
 if v is not False:
     if v is True:
         opts['vnc'] = 'on'
+
+    # The VNC options need to be processed in order to extract and mask
+    # the 'password' attribute and to handle aliases for other elements.
+    vncpassword = None
+    vopts = expandopts(opts['vnc'])
+    for k, v in list(vopts.items()):
+        if not len(v):
+            try:
+                newopts = expandopts(aliases['vnc'][k])
+            except KeyError:
+                pass
+            else:
+                del vopts[k]
+                # This way round means that the keys from vopts will overwrite
+                # any duplicates in newopts.
+                newopts |= vopts
+                vopts = newopts
+        elif k == 'password':
+            vncpassword = file_or_string(v)
+            del vopts[k]
+
+    opts['vnc'] = collapseopts(vopts)
+
     args.extend(['-s', '{0}:0,fbuf,vga={1},{2}'.format(
         VNC_SLOT, opts['vga'], opts['vnc'])])
     if boolv(opts['xhci'], 'xhci'):
@@ -789,6 +833,9 @@ writecfg(fh, '#\n# Generated from zone configuration\n#')
 for line in p.stdout.splitlines():
     if line.startswith('config.dump'): continue
     writecfg(fh, line)
+
+if vncpassword:
+    writecfg(fh, f'pci.0.{VNC_SLOT}.0.password={vncpassword}')
 
 if not testmode:
     tf = fh.name

--- a/src/man/bhyve.5
+++ b/src/man/bhyve.5
@@ -10,9 +10,9 @@
 .\"
 .\" Copyright 2016, Joyent, Inc.
 .\" Copyright 2016, OmniTI Computer Consulting, Inc. All Rights Reserved.
-.\" Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+.\" Copyright 2022 OmniOS Community Edition (OmniOSce) Association.
 .\"
-.Dd September 11, 2021
+.Dd February 7, 2022
 .Dt BHYVE 5
 .Os
 .Sh NAME
@@ -193,6 +193,13 @@ Available options are:
 .It
 .Sy virtio-blk Pq default
 .El
+.It Sy diskif Ns Ar N Ar type
+.Pp
+Override the
+.Sy diskif
+.Ar type
+for the disk at target
+.Ar N .
 .It Sy dns-domain Ar domainname
 .Pp
 The DNS domain name for the guest.

--- a/src/man/bhyve.5
+++ b/src/man/bhyve.5
@@ -12,7 +12,7 @@
 .\" Copyright 2016, OmniTI Computer Consulting, Inc. All Rights Reserved.
 .\" Copyright 2022 OmniOS Community Edition (OmniOSce) Association.
 .\"
-.Dd February 7, 2022
+.Dd February 11, 2022
 .Dt BHYVE 5
 .Os
 .Sh NAME
@@ -24,7 +24,8 @@ A
 branded zone uses the
 .Xr brands 5
 framework to provide an environment for running a virtual machine under the
-bhyve hypervisor.
+.Xr bhyve 1m
+hypervisor.
 .Sh CONFIGURATION
 .Nm
 zones are configured mostly via custom attributes in the zone configuration.
@@ -33,11 +34,9 @@ Supported attributes are:
 .Bl -tag -width Ds
 .It Xo Sy acpi
 .Sm off
-.Ar on
-|
-.Ar off
-.Xc
+.Ar on | off
 .Sm on
+.Xc
 .Pp
 This is a legacy option that no longer has any effect.
 .It Sy bootdisk Ar path Ns Op , Ns Cm serial Ns = Ns Ar serial
@@ -104,15 +103,9 @@ Each image file must also be mapped into the zone using an
 block, as shown in the example below.
 .It Xo Sy cloud-init
 .Sm off
-.Ar on
-|
-.Ar off
-|
-.Ar filename
-|
-.Ar URL
-.Xc
+.Ar on | off | filename | URL
 .Sm on
+.Xc
 .Pp
 When this option is enabled, and set to
 .Ar on
@@ -255,13 +248,9 @@ Note that only the accelerated virtio interface supports filtering using the
 zone firewall.
 .It Xo Sy password
 .Sm off
-.Ar string
-|
-.Ar hash
-|
-.Ar filename
-.Xc
+.Ar string | hash | filename
 .Sm on
+.Xc
 .Pp
 When the
 .Sy cloud-init
@@ -271,9 +260,9 @@ will be passed to the guest which can use it to set the password for the
 default user.
 Depending on the guest, this may be the root user or a distribution-dependant
 initial user.
-.Ar password
-can be provided as a fixed string, a pre-computed hash or a path to a file
-that contains the desired password or password hash.
+The password can be provided as a fixed string, a pre-computed hash or a path
+to a file that contains the desired password or password hash, relative to
+the global zone root.
 .It Sy priv.debug Ar on Ns | Ns Ar off
 Set to
 .Ar on
@@ -346,11 +335,9 @@ These are included in the data passed to the guest when the
 option is enabled.
 .It Xo Sy rng
 .Sm off
-.Ar on
-|
-.Ar off
-.Xc
+.Ar on | off
 .Sm on
+.Xc
 .Pp
 Set to
 .Ar on
@@ -360,9 +347,7 @@ to the guest
 .Pq default: Ar off .
 .It Xo Sy sshkey
 .Sm off
-.Ar string
-|
-.Ar filename
+.Ar string | filename
 .Xc
 .Sm on
 .Pp
@@ -455,20 +440,19 @@ result in I/O port queries and fail to boot if I/O decode is disabled.
 .El
 .It Xo Sy vnc
 .Sm off
-.Ar on
-|
-.Ar wait
-|
-.Ar off
-|
-.Ar options
-.Xc
+.Ar on | wait | off | options
 .Sm on
+.Xc
 .Pp
 This parameter controls whether a virtual frambuffer is attached to the
 guest and made available via VNC.
 Available options are:
 .Bl -tag -width Ds
+.It Sy off
+Disable the framebuffer.
+This is the same as omitting the
+.Sy vnc
+attribute.
 .It Sy on
 An alias for
 .Sy unix=/tmp/vm.vnc
@@ -480,12 +464,8 @@ An alias for
 .Sy wait,unix=/tmp/vm.vnc
 which is identical to
 .Sy on
-except that the zone boot is halted until a VNC connection is established.
-.It Sy off
-Disable the framebuffer.
-This is the same as omitting the
-.Sy vnc
-attribute.
+except that the zone boot is halted until the first VNC connection is
+established.
 .It Sy unix Ns = Ns Ar path
 Sets up a VNC server on a UNIX socket at the specified
 .Ar path .
@@ -496,8 +476,17 @@ Specifies the horizontal screen resolution
 .It Sy h Ns = Ns Ar pixels
 Specifies the vertical screen resolution
 .Pq default: 768, max: 1200
+.It Xo
+.Sm off
+.Sy password = Ar string | filename
+.Sm on
+.Xc
+Specifies a password for the VNC server.
+If no password is specified, no authentication is required.
+The password can be provided as a fixed string or a path to a file that
+contains the desired password, relative to the global zone root.
 .It Sy wait
-Pause boot until a VNC connection is established.
+Pause boot until the first VNC connection is established.
 .El
 .Pp
 Multiple options can be provided, separated by commas.
@@ -523,11 +512,9 @@ If you prefer, you can also use the real socat utility that's shipped in core:
 .Ed
 .It Xo Sy xhci
 .Sm off
-.Ar on
-|
-.Ar off
-.Xc
+.Ar on | off
 .Sm on
+.Xc
 .Pp
 Enable or disable the emulated USB tablet interface along with the emulated
 framebuffer.


### PR DESCRIPTION
This is provided mostly for test and development purposes:

```
omnios@bhyvetest:~$ pfexec diskinfo
TYPE    DISK                    VID      PID              SIZE          RMV SSD
NVME    c1t589CFC2045C20001d0   NVMe     bhyve-NVMe         15.00 GiB   no  yes
-       c4t0d0                  Virtio   Block Device       10.00 GiB   no  no
SATA    c5t0d0                  BHYVE    SATA DISK           2.00 GiB   no  no
```