### PR TITLE
Fix broken pkgsrc cloning

### DIFF
--- a/src/brand/ipkg/common.ksh
+++ b/src/brand/ipkg/common.ksh
@@ -320,7 +320,7 @@ unconfigure_zone() {
 
 	ZONE_BRAND=`zoneadm list -pc | /usr/bin/nawk -v zone=$ZONENAME -F':' '$2 == zone { print $6 }'`
 	case "$ZONE_BRAND" in
-	    ipkg|lipkg|sparse|vm)
+	    ipkg|lipkg|sparse|pkgsrc|vm)
 		zlogin -S $ZONENAME /usr/lib/brand/ipkg/system-unconfigure -R /a \
 		    >/dev/null 2>&1
 		if (( $? != 0 )); then


### PR DESCRIPTION
In r151040, trying to `zoneadm clone` a pkgsrc zone fails with 

```
ERROR: Zone unconfiguration failed
```

After making the change in this patch I have been able to clone pkgsrc zones successfully. 