### PR TITLE
Upstream sync

### DIFF
--- a/README.sync
+++ b/README.sync
@@ -4,11 +4,11 @@
 The pkg5 components have been updated to the latest upstream solaris-ips
 as of:
 
-commit dc798e4a23b735fa814734f33ed3ae1a72a83a47
-Author: Chandana R <chandana.r@oracle.com>
-Date:   Sun Nov 14 22:04:15 2021 -0800
+commit 00023c2411c7f2d93712dde9d516d67cb6d2782b
+Author: Peter Dennis <peter.dennis@oracle.com>
+Date:   Mon Jan 24 03:43:37 2022 -0800
 
-    32458925 deliver python 3.9 modules for pkg
+    27640082 IPS Test suite broken for depotd tests
 
 -----------------------------------------------------------------------------
 

--- a/doc/client_api_versions.txt
+++ b/doc/client_api_versions.txt
@@ -1,3 +1,10 @@
+Version 84:
+Compatible with clients using versions 72-83.
+
+    pkg.client.api.PlanDescription has changed as follows:
+        * Added method:
+                find_removal() returns True if the named file is being removed
+
 Version 83:
 Compatible with clients using versions 72-82.
 

--- a/src/client.py
+++ b/src/client.py
@@ -22,7 +22,7 @@
 
 #
 # Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
-# Copyright (c) 2007, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2007, 2022, Oracle and/or its affiliates.
 #
 
 #
@@ -768,6 +768,10 @@ WARNING: The boot environment being modified is not the active one.
 
 """))
 
+        # a = change(!!!) (due to fix or mediator/variant/facet)
+        # c = update
+        # r = remove
+        # i = install
         a, r, i, c = [], [], [], []
         for src, dest in plan.get_changes():
                 if dest is None:
@@ -850,6 +854,20 @@ WARNING: The boot environment being modified is not the active one.
                 for s in status:
                         logger.info("{0} {1}".format(s[0].rjust(rjust_status),
                             s[1].rjust(rjust_value)))
+
+        # Display list of removed packages in the default output.
+        # Verbose output already has this in a different form.
+        if not verbose and r:
+                logger.info(_("\nRemoved Packages:\n"))
+                removals = [src.pkg_stem for src, dest in r]
+                if len(r) < 5:
+                        logger.info("  " + "\n  ".join(removals))
+                else:
+                        logger.info("  " + "\n  ".join(removals[:5]))
+                        logger.info("  ...")
+                        logger.info("  {0:d} additional removed packages. "
+                                    "Use 'pkg history' to view "
+                                    "the full list.".format(len(r) - 5))
 
         need_blank = True
         if "mediators" in disp and mediators:

--- a/src/client.py
+++ b/src/client.py
@@ -857,15 +857,15 @@ WARNING: The boot environment being modified is not the active one.
 
         # Display list of removed packages in the default output.
         # Verbose output already has this in a different form.
-        if not verbose and r:
+        if not verbose and r and op in [PKG_OP_INSTALL, PKG_OP_UPDATE]:
                 logger.info(_("\nRemoved Packages:\n"))
                 removals = [src.pkg_stem for src, dest in r]
-                if len(r) < 5:
+                if len(r) <= 5:
                         logger.info("  " + "\n  ".join(removals))
                 else:
                         logger.info("  " + "\n  ".join(removals[:5]))
                         logger.info("  ...")
-                        logger.info("  {0:d} additional removed packages. "
+                        logger.info("  {0:d} additional removed package(s). "
                                     "Use 'pkg history' to view "
                                     "the full list.".format(len(r) - 5))
 

--- a/src/client.py
+++ b/src/client.py
@@ -3958,6 +3958,14 @@ package manifests.""", """\
 These packages contain no actions with the fields specified using the -o
 option. Please specify other fields, or use the -m option to show the raw
 package manifests.""", len(pargs)))
+                        elif not actionlist:
+                                error(gettext.ngettext("""\
+This package contains no actions specified using the -t option. Please
+specify other fields, or use the -m option to show the raw package
+manifests.""", """\
+These package contains no actions specified using the -t option. Please
+specify other fields, or use the -m option to show the raw package
+manifests.""", len(pargs)))
                         else:
                                 error(gettext.ngettext("""\
 This package delivers no filesystem content, but may contain metadata. Use

--- a/src/man/pkg.1
+++ b/src/man/pkg.1
@@ -1,6 +1,6 @@
 .\" Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
 .\" Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
-.Dd March 12, 2021
+.Dd August 17, 2021
 .Dt PKG 1
 .Os
 .Sh NAME
@@ -2228,6 +2228,10 @@ Set the version of the mediated interface to use.
 .Pp
 If the specified mediator version and/or implementation is not currently
 available, any links using the specified mediators are removed.
+If, during an update, the mediated link target is removed, a warning will
+be produced indicating this.
+If the update had created a new boot environment, the boot environment will be
+left mounted and not activated.
 .Pp
 For all other options, see the
 .Cm install

--- a/src/modules/client/api.py
+++ b/src/modules/client/api.py
@@ -110,9 +110,9 @@ from pkg.smf import NonzeroExitException
 # things like help(pkg.client.api.PlanDescription)
 from pkg.client.plandesc import PlanDescription # pylint: disable=W0611
 
-CURRENT_API_VERSION = 83
+CURRENT_API_VERSION = 84
 COMPATIBLE_API_VERSIONS = frozenset([72, 73, 74, 75, 76, 77, 78, 79, 80, 81,
-    82, CURRENT_API_VERSION])
+    82, 83, CURRENT_API_VERSION])
 CURRENT_P5I_VERSION = 1
 
 # Image type constants.
@@ -3033,7 +3033,14 @@ in the environment or by setting simulate_cmdpath in DebugValues.""")
                                 error = apx.ActuatorException(e)
                                 self.log_operation_end(error=error)
                                 raise error
-
+                        except apx.InvalidMediatorTarget as e:
+                                # Mount a new BE but do not activate it in case the
+                                # missing mediator target will cause a broken system.
+                                # Allows the admin to take the appropriate action.
+                                if self.__new_be:
+                                        be.restore_image()
+                                self.log_operation_end(error=e)
+                                raise e
                         except Exception as e:
                                 if self.__new_be:
                                         be.restore_image()

--- a/src/modules/client/api_errors.py
+++ b/src/modules/client/api_errors.py
@@ -3533,5 +3533,15 @@ class UnsupportedFacetChange(ApiException):
                 return _("Changing '{facet}' to '{value}' is not supported.".
                          format(facet=self.facet, value=self.value))
 
+class InvalidMediatorTarget(ApiException):
+        """ Used to indicate if the target of a mediated link is missing,
+            which could lead to a broken system on a reboot."""
+
+        def __init__(self, medmsg):
+            self.medmsg = medmsg
+
+        def __str__(self):
+            return self.medmsg
+
 # Vim hints
 # vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/bootenv.py
+++ b/src/modules/client/bootenv.py
@@ -20,7 +20,7 @@
 # CDDL HEADER END
 #
 
-# Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2008, 2021, Oracle and/or its affiliates.
 # Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
 
 import errno
@@ -639,9 +639,10 @@ beadm activate {be_name_clone}
                 if self.is_live_BE:
                         logger.error(_("The running system has not been "
                             "modified. Modifications were only made to a clone "
-                            "of the running system.  This clone is mounted at "
-                            "{0} should you wish to inspect it.").format(
-                            self.clone_dir))
+                            "({0}) of the running system. This clone is "
+                            "mounted at {1} should you wish to inspect "
+                            "it.").format(
+                            self.be_name_clone, self.clone_dir))
 
                 else:
                         # Rollback and destroy the snapshot.

--- a/src/modules/client/client_api.py
+++ b/src/modules/client/client_api.py
@@ -1042,6 +1042,12 @@ def __api_execute_plan(operation, api_inst):
         except api_errors.ImageInsufficentSpace as e:
                 _error_json(str(e), errors_json=errors_json)
                 rval = __prepare_json(EXIT_OOPS, errors=errors_json)
+        except api_errors.InvalidMediatorTarget as e:
+                _error_json(str(e), errors_json=errors_json)
+                # An invalid target means the operation completed but
+                # the user needs to consider the state of any image so
+                # return a EXIT_PARTIAL.
+                rval = __prepare_json(EXIT_PARTIAL, errors=errors_json)
         except Exception as e:
                 _error_json(_("An unexpected error happened during "
                     "{operation}: {err}").format(

--- a/src/modules/client/imageplan.py
+++ b/src/modules/client/imageplan.py
@@ -158,6 +158,7 @@ class ImagePlan(object):
                 self.__fixups = {}
                 self.operations_pubs = None # pubs being operated in hydrate
 
+                self.invalid_meds = defaultdict(set) # targetless mediated links
                 self.__old_excludes = image.list_excludes()
                 self.__new_excludes = self.__old_excludes
 
@@ -3906,6 +3907,15 @@ class ImagePlan(object):
                 # These must be done after action merging.
                 self.__evaluate_pkg_preserved_files()
                 self.__evaluate_pkg_downloads()
+                # If there are invalid mediators then message about it
+                # for the no execute (-n) or zones case. If an update
+                # in the global zone an exception will be raised later.
+                if self.invalid_meds:
+                        if self.__noexecute or self.image.is_zone():
+                                medmsg = self.__make_med_msg()
+                                timestamp = misc.time_to_timestamp(time.time())
+                                self.pd.add_item_message("warning", timestamp,
+                                                         MSG_WARNING, medmsg)
 
         def __update_avail_space(self):
                 """Update amount of available space on FS"""
@@ -4358,7 +4368,46 @@ class ImagePlan(object):
 
                 return prop_mediators
 
-        def __finalize_mediation(self, prop_mediators):
+        def __full_target_path(self, linkpath):
+                """ Resolves a link target to a relative pathname
+                    of the image being modified. """
+
+                rootpath = os.path.join(self.image.root, linkpath)
+                reallinkpath = os.path.normpath(rootpath)
+
+                targetname = os.path.realpath(reallinkpath)
+                # Should only trigger if there is something wrong with the
+                # associated package manifest.
+                assert(targetname.startswith(self.image.root))
+                # Chop the image.root off as a relative path to match
+                # the package manifests is required.
+                res = targetname[len(self.image.root):]
+                # Zones will have an extra '/' at the start of the pathname,
+                # so remove it.
+                if res.startswith("/"):
+                        return res[1:]
+                return res
+
+        def __make_med_msg(self):
+                """ Helper function to create the message string for poorly
+                    configured mediators. """
+                fmt_str = "  {0:24} {1}\n"
+                res = _("The following mediated link targets do not exist, "
+                        "please reset the links via pkg set-mediator:\n")
+                res = res + fmt_str.format(_("MEDIATOR"), _("REMOVED PATH(S)"))
+                for med in self.invalid_meds:
+                        res = res + fmt_str.format(med,
+                                                   ", ".join(
+                                                   self.invalid_meds[med]))
+                return res
+
+        def __is_target_removed(self, filepath):
+                """ Check to see if the named filepath is being removed in
+                    the plan."""
+                removed = self.pd.find_removal(filepath)
+                return removed
+
+        def __finalize_mediation(self, prop_mediators, mediated_del_path_target):
                 """Merge requested and previously configured mediators that are
                 being set but don't affect the plan and update proposed image
                 configuration."""
@@ -4367,10 +4416,20 @@ class ImagePlan(object):
                 for m in self.pd._new_mediators:
                         prop_mediators.setdefault(m, self.pd._new_mediators[m])
                 for m in cfg_mediators:
-                        if m in prop_mediators:
-                                continue
 
                         mediation = cfg_mediators[m]
+                        # Check to see if the proposed mediator has removed
+                        # targets, if so then upon an update there will be
+                        # invalid mediated links so add the target to the
+                        # invalid list, otherwise it is okay so nothing to
+                        # do.
+                        if m in prop_mediators:
+                                if m in mediated_del_path_target:
+                                     for target in mediated_del_path_target[m]:
+                                         if self.__is_target_removed(target):
+                                               self.invalid_meds[m].add(target)
+                                continue
+
                         new_mediation = mediation.copy()
                         if mediation.get("version-source") != "local":
                                 new_mediation.pop("version", None)
@@ -4536,6 +4595,7 @@ class ImagePlan(object):
                     self.image.cfg.mediators
 
                 mediated_removed_paths = set()
+                mediated_del_path_target = defaultdict(set)
                 for p in self.pd.pkg_plans:
                         pt.plan_add_progress(pt.PLAN_ACTION_MERGE)
                         for src, dest in p.gen_removal_actions():
@@ -4576,12 +4636,22 @@ class ImagePlan(object):
                                         # string.
                                         cfg_version = \
                                             cfg_version.get_short_version()
+
+                                cfg_version_source = mediation.get("version-source")
                                 cfg_impl = mediation.get("implementation")
+                                cfg_impl_source = mediation.get("implementation-source")
 
                                 if src_version == cfg_version and \
                                     mediator_impl_matches(src_impl, cfg_impl):
                                         mediated_removed_paths.add(
                                             src.attrs["path"])
+                                        # Need the target to be a full path
+                                        # so it can be found in the plan.
+                                        if cfg_version_source == "local" or \
+                                             cfg_impl_source == "local":
+                                                 binpath = src.attrs["path"]
+                                                 target = self.__full_target_path(binpath)
+                                                 mediated_del_path_target[mediator].add(target)
 
                 self.pd.update_actions = []
                 self.pd._rm_aliases = {}
@@ -4980,7 +5050,7 @@ class ImagePlan(object):
                 pt.plan_add_progress(pt.PLAN_ACTION_MEDIATION)
 
                 # Finalize link mediation.
-                self.__finalize_mediation(prop_mediators)
+                self.__finalize_mediation(prop_mediators, mediated_del_path_target)
 
                 pt.plan_done(pt.PLAN_ACTION_MEDIATION)
 
@@ -5643,6 +5713,13 @@ class ImagePlan(object):
                                         traceback.format_stack())
                         if self.__preexecuted_indexing_error is not None:
                                 raise self.__preexecuted_indexing_error
+
+                # As the very last thing, check if there are any broken
+                # mediators.
+                if self.invalid_meds and not self.image.is_zone():
+                        medmsg = self.__make_med_msg()
+                        raise api_errors.InvalidMediatorTarget(medmsg)
+
 
         def __is_image_empty(self):
                 try:

--- a/src/modules/client/plandesc.py
+++ b/src/modules/client/plandesc.py
@@ -69,6 +69,7 @@ EXECUTED_ERROR    = 7 # failed
 OP_STAGE_PLAN     = 0
 OP_STAGE_PREP     = 1
 OP_STAGE_EXEC     = 2
+OP_STAGE_PRINTED  = 3 # The message has been consumed by a client
 
 class _ActionPlan(collections.namedtuple("_ActionPlan", "p src dst")):
         """A named tuple used to keep track of all the actions that will be
@@ -446,6 +447,15 @@ class PlanDescription(object):
                         ret.append(out)
 
                 return ret
+
+        def find_removal(self, filename):
+                """ Has the named file been tagged for removal ?"""
+
+                for ap in self.removal_actions:
+                        if ap.src.name == "file" and ap.src.attrs["path"] == filename:
+                               return True
+
+                return False
 
         def get_mediators(self):
                 """Returns list of strings describing mediator changes."""
@@ -918,6 +928,7 @@ class PlanDescription(object):
                                         ordered_list.append([item_id, None] + \
                                             PlanDescription. \
                                                     __msg_dict2list(msg))
+                                        msg["msg_stage"] = OP_STAGE_PRINTED
                         for si, si_list in six.iteritems(
                             self._item_msgs[item_id]):
                                 if si == "messages":
@@ -929,6 +940,7 @@ class PlanDescription(object):
                                         ordered_list.append([si, item_id] + \
                                             PlanDescription. \
                                                     __msg_dict2list(msg))
+                                        msg["msg_stage"] = OP_STAGE_PRINTED
                 for entry in sorted(ordered_list, key=operator.itemgetter(2)):
                         yield entry
 
@@ -947,6 +959,7 @@ class PlanDescription(object):
                                         if (stages is not None and
                                             mp["msg_stage"] not in stages):
                                                 continue
+                                        mp["msg_stage"] = OP_STAGE_PRINTED
                                         yield([iid, pid] + \
                                             PlanDescription.__msg_dict2list(mp))
 

--- a/src/modules/misc.py
+++ b/src/modules/misc.py
@@ -20,7 +20,7 @@
 # CDDL HEADER END
 #
 
-# Copyright (c) 2007, 2020, Oracle and/or its affiliates.
+# Copyright (c) 2007, 2022, Oracle and/or its affiliates.
 # Copyright 2014, OmniTI Computer Consulting, Inc. All rights reserved.
 # Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
@@ -3067,7 +3067,8 @@ def cmp(a, b):
                 return NotImplemented
 
 def set_memory_limit(bytes, allow_override=True):
-        """Limit memory consumption of current process to 'bytes'."""
+        """Limit memory consumption of current process to 'bytes'.
+           This only limits the brk() and mmap() calls made by python."""
 
         if allow_override:
                 try:
@@ -3076,9 +3077,9 @@ def set_memory_limit(bytes, allow_override=True):
                         pass
 
         try:
-                resource.setrlimit(resource.RLIMIT_DATA, (bytes, bytes))
+                resource.setrlimit(resource.RLIMIT_VMEM, (bytes, bytes))
         except AttributeError:
-                # If platform doesn't support RLIMIT_DATA, just ignore it.
+                # If platform doesn't support RLIMIT_VMEM, just ignore it.
                 pass
         except ValueError:
                 # An unprivileged user can not raise a previously set limit,

--- a/src/modules/server/api.py
+++ b/src/modules/server/api.py
@@ -20,7 +20,7 @@
 # CDDL HEADER END
 
 #
-# Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2008, 2022, Oracle and/or its affiliates.
 #
 
 import cherrypy
@@ -185,7 +185,6 @@ class CatalogInterface(_Interface):
                                                 del a
                                                 break
                                         del a
-                                    else:
                                         allowed[pkg_name].append((f, sn))
 
                 sort_ver = itemgetter(0)

--- a/src/pydates
+++ b/src/pydates
@@ -13,7 +13,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #
-# Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2022, Oracle and/or its affiliates.
 
 
 # Create a dictionary (timestamps) mapping paths of python files in the modules
@@ -21,29 +21,20 @@
 # filesystem timestamp.  If it's unchanged, its timestamp is the timestamp of
 # the last changeset which modified it.
 
-from __future__ import print_function
 import os
 import time
 import mercurial.cmdutil as cmdutil
 import mercurial.match as matchmod
 from mercurial import localrepo
 from mercurial.ui import ui
+from mercurial import encoding
 
 myui = ui()
-try:
-    # Since Mercurial 4.8:
-    repo = localrepo.instance(myui, cmdutil.findrepo(os.getcwd()), False)
-except TypeError:
-    # Mercurial 4.8+ causes pylint to complain about the old use of the
-    # __init__ constructor, which is valid when running using versions prior
-    # to 4.8 (the arg count jumped from 3 to 13). So to pass pylint with both
-    # old and new versions, we need to disable the arg check around this call.
-    # pylint: disable=no-value-for-parameter
-    repo = localrepo.localrepository(myui, cmdutil.findrepo(os.getcwd()))
-    # pylint: disable=no-value-for-parameter
+repo = localrepo.instance(myui, cmdutil.findrepo(encoding.getcwd()), False)
 
 # Match only python files in src/modules.
-matchfn = matchmod.match(repo.root, os.getcwd(), patterns=["re:src/modules/.*\.py$"])
+matchfn = matchmod.match(repo.root, encoding.getcwd(),
+                         patterns=[rb"re:src/modules/.*\.py$"])
 
 # Dummy prep function.
 def prep(ctx, fns):
@@ -52,8 +43,8 @@ def prep(ctx, fns):
 # Get the set of matching files in the working directory parent.
 manifest = set(
     f
-    for f in repo["."]
-    if f.startswith("src/modules/") and f.endswith(".py")
+    for f in repo[b"."]
+    if f.startswith(b"src/modules/") and f.endswith(b".py")
 )
 
 # Find out which files have changed.
@@ -81,8 +72,11 @@ for ctx in cmdutil.walkchangerevs(repo, matchfn, {'rev': revs}, prep):
                         timestamps[f] = ctx.date()[0]
                         manifest.remove(f)
 
-for name, stamp in timestamps.iteritems():
-        print(stamp, name)
+for name, stamp in timestamps.items():
+        # This produces output that is consumed by setup.py, the types
+        # returned here must be expected by the setup.py otherwise
+        # the setup.py will default to the timestamp of the workspace.
+        print(stamp, name.decode())
 
 # Get the timestamp of the workspace.  If it's unmodified, then use the
 # timestamp of the parent of the working directory, and the latest timestamp of
@@ -96,4 +90,4 @@ if any(modadd):
             for f in modadd
         )), ".")
 else:
-        print(repo["."].date()[0], ".")
+        print(repo[b"."].date()[0], ".")

--- a/src/svc/pkg-system-repository.xml
+++ b/src/svc/pkg-system-repository.xml
@@ -1,30 +1,30 @@
 <?xml version="1.0"?>
 <!--
-	CDDL HEADER START
+  CDDL HEADER START
+  
+  The contents of this file are subject to the terms of the
+  Common Development and Distribution License (the "License").
+  You may not use this file except in compliance with the License.
 
-	The contents of this file are subject to the terms of the
-	Common Development and Distribution License (the "License").
-	You may not use this file except in compliance with the License.
+  You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+  or http://www.opensolaris.org/os/licensing.
+  See the License for the specific language governing permissions
+  and limitations under the License.
 
-	You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
-	or http://www.opensolaris.org/os/licensing.
-	See the License for the specific language governing permissions
-	and limitations under the License.
+  When distributing Covered Code, include this CDDL HEADER in each
+  file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+  If applicable, add the following below this CDDL HEADER, with the
+  fields enclosed by brackets "[]" replaced with your own identifying
+  information: Portions Copyright [yyyy] [name of copyright owner]
 
-	When distributing Covered Code, include this CDDL HEADER in each
-	file and include the License file at usr/src/OPENSOLARIS.LICENSE.
-	If applicable, add the following below this CDDL HEADER, with the
-	fields enclosed by brackets "[]" replaced with your own identifying
-	information: Portions Copyright [yyyy] [name of copyright owner]
+  CDDL HEADER END
 
-	CDDL HEADER END
+  Copyright (c) 2011, 2021, Oracle and/or its affiliates.
 
-	Copyright (c) 2011, 2013 Oracle and/or its affiliates.  All rights reserved.
-
-	NOTE:  This service manifest is not editable; its contents will
-	be overwritten by package or patch operations, including
-	operating system upgrade.  Make customizations in a different
-	file.
+  NOTE:  This service manifest is not editable; its contents will
+  be overwritten by package or patch operations, including
+  operating system upgrade.  Make customizations in a different
+  file.
 -->
 
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
@@ -113,16 +113,18 @@
 		</exec_method>
 
 
-                <property_group name='config' type='application'>
-                        <stability value='Evolving' />
-                        <!-- The port we listen on -->
-                        <propval name='port' type='count' value='1008' />
-                        <!-- The host we're running on -->
-                        <propval name='host' type='astring' value='127.0.0.1' />
-                        <!-- Where we store apache logs -->
-                        <propval name='log_dir' type='astring'
-                                value='/var/log/pkg/sysrepo' />
-                        <!-- Where we store runtime versions of our
+		<property_group name='config' type='application'>
+			<stability value='Evolving' />
+			<!-- The Image root -->
+			<propval name='image_root' type='astring' value='/' />
+			<!-- The port we listen on -->
+			<propval name='port' type='count' value='1008' />
+			<!-- The host we're running on -->
+			<propval name='host' type='astring' value='127.0.0.1' />
+			<!-- Where we store apache logs -->
+			<propval name='log_dir' type='astring'
+				value='/var/log/pkg/sysrepo' />
+			<!-- Where we store runtime versions of our
 			 configuration -->
                         <propval name='runtime_dir' type='astring'
 				value='/system/volatile/pkg/sysrepo' />
@@ -168,6 +170,76 @@
 			<documentation>
 				<manpage title='pkg.sysrepo' section='1M' />
 			</documentation>
+
+			<pg_pattern name='config'>
+				<!-- Private Internal Properties -->
+				<prop_pattern name='value_authorization'>
+					<visibility value='hidden'/>
+				</prop_pattern>
+				<prop_pattern name='image_root'>
+					<description><loctext xml:lang='C'>
+						Image root. Should almost always be /.
+						Intended for internal tool use only.
+					</loctext></description>
+					<visibility value='hidden'/>
+				</prop_pattern>
+				<prop_pattern name='template_dir'>
+					<description><loctext xml:lang='C'>
+						Intended for internal tool use only.
+					</loctext></description>
+					<visibility value='hidden'/>
+				</prop_pattern>
+				<prop_pattern name='runtime_dir'>
+					<description><loctext xml:lang='C'>
+						Intended for internal tool use only.
+					</loctext></description>
+					<visibility value='hidden'/>
+				</prop_pattern>
+				<prop_pattern name='log_dir'>
+					<description><loctext xml:lang='C'>
+						Intended for internal tool use only.
+					</loctext></description>
+					<visibility value='hidden'/>
+				</prop_pattern>
+				<prop_pattern name='host'>
+					<description><loctext xml:lang='C'>
+						Intended for internal tool use only.
+					</loctext></description>
+					<visibility value='hidden'/>
+				</prop_pattern>
+
+
+				<!-- 
+				    The remainder of the properties are documented,
+				    in pkg.sysrepo(8)
+				-->
+				<prop_pattern name='cache_dir' type='astring'>
+					<description><loctext xml:lang='C'>
+						Absolute path to the directory used for caching responses from the publishers.  A special value of 'memory' indicates that an in-memory cache should be used.  The special value of 'None' indicates that the system repository should not perform caching.
+					</loctext></description>
+				</prop_pattern>
+				<prop_pattern name='port' type='count'>
+					<description><loctext xml:lang='C'>
+						The port that the system repository should use to listen on for requests.
+					</loctext></description>
+				</prop_pattern>
+				<prop_pattern name='cache_max' type='count'>
+					<description><loctext xml:lang='C'>
+						An integer value in megabytes that defines the maximum cache size for the system repository.
+					</loctext></description>
+				</prop_pattern>
+				<prop_pattern name='http_proxy' type='astring'>
+					<description><loctext xml:lang='C'>
+						A string of the form scheme://hostname[:port] that defines a web proxy that the system repository can use to access http-based package repositories.
+					</loctext></description>
+				</prop_pattern>
+				<prop_pattern name='https_proxy' type='astring'>
+					<description><loctext xml:lang='C'>
+						A string of the form scheme://hostname[:port] that defines a web proxy that the system repository can use to access https-based package repositories.
+					</loctext></description>
+				</prop_pattern>
+			</pg_pattern>
+
 		</template>
 
 	</instance>

--- a/src/svc/svc-pkg-sysrepo
+++ b/src/svc/svc-pkg-sysrepo
@@ -1,4 +1,4 @@
-#!/sbin/sh
+#!/bin/sh
 #
 # CDDL HEADER START
 #
@@ -20,7 +20,7 @@
 # CDDL HEADER END
 #
 #
-# Copyright (c) 2011, 2013 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2021, Oracle and/or its affiliates.
 #
 
 . /lib/svc/share/smf_include.sh
@@ -80,7 +80,7 @@ run_sysrepo() {
 	fi
 
         /usr/lib/pkg.sysrepo \
-               -R / \
+               -R ${SYSREPO_IMAGE_ROOT} \
                -c ${SYSREPO_CACHE_DIR} \
                -h ${SYSREPO_HOST} \
                -l ${SYSREPO_LOG_DIR} \
@@ -122,6 +122,11 @@ kill_htcacheclean() {
 		    "not_fatal"
         fi
 }
+
+getprop config/image_root
+if [ "${PROPVAL}" != "" ]; then
+	SYSREPO_IMAGE_ROOT=${PROPVAL}
+fi
 
 getprop config/host
 if [ "${PROPVAL}" != "" ] ; then

--- a/src/sysrepo.py
+++ b/src/sysrepo.py
@@ -101,7 +101,6 @@ HTTP_PORT = 80
 # all of the above can be modified with command line arguments.
 #
 
-SYSREPO_CRYPTO_FILENAME = "crypto.txt"
 SYSREPO_HTTP_TEMPLATE = "sysrepo_httpd.conf.mako"
 SYSREPO_HTTP_FILENAME = "sysrepo_httpd.conf"
 
@@ -706,32 +705,36 @@ def _write_httpd_conf(runtime_dir, log_dir, template_dir, host, port, cache_dir,
                     _("Unable to write sysrepo_httpd.conf: {0}").format(err))
 
 def _write_crypto_conf(runtime_dir, uri_pub_map):
-        """Writes the crypto.txt file, containing keys and certificates
-        in order for the system repository to proxy to https repositories."""
+        """Writes the proxy-creds-${pub}.pem file, containing keys and
+        certificates in order for the system repository to proxy to https
+        repositories."""
 
         try:
-                crypto_path = os.path.join(runtime_dir, SYSREPO_CRYPTO_FILENAME)
-                open(crypto_path, "w").close()
-                os.chmod(crypto_path, 0o600)
-                written_crypto_content = False
-
+                # It is possible that a remote SSL publisher may not send a CA
+                # name back to identify the key/cert pair to use. 'mod_ssl', in
+                # this instance will use the first key/cert in the
+                # <SSLProxyMachineCertificateFile> but depending upon the order
+                # of the configured publishers it could be wrong. So workaround
+                # this behavior by specifying a file per publisher.
                 for repo_list in uri_pub_map.values():
                         for (pub, cert_path, key_path, hash, proxy, utype) in \
                             repo_list:
-                                if cert_path and key_path:
-                                       crypto_file = open(crypto_path, "a")
-                                       crypto_file.writelines(open(cert_path))
-                                       crypto_file.writelines(open(key_path))
-                                       crypto_file.close()
-                                       written_crypto_content = True
-
-                # Apache needs us to have some content in this file
-                if not written_crypto_content:
-                        crypto_file = open(crypto_path, "w")
-                        crypto_file.write(
-                            "# this space intentionally left blank\n")
-                        crypto_file.close()
-                os.chmod(crypto_path, 0o400)
+                                cred_file = os.path.join(runtime_dir,
+                                    "proxy-creds-" + pub + ".pem")
+                                # Ensure that the file is truncated prior to
+                                # writing to it.
+                                with open(os.open(cred_file, os.O_CREAT |
+                                    os.O_WRONLY, 0o400), 'w') as fh_cred:
+                                        if cert_path and key_path:
+                                                fh_cred.writelines(open(cert_path))
+                                                fh_cred.writelines(open(key_path))
+                                        else:
+                                                fh_cred.write(
+                                                    "# Apache mod_ssl requires "
+                                                    "that this file be more than"
+                                                    " zero length even when it "
+                                                    "does not contain a PEM "
+                                                    "format key/cert.\n")
         except OSError as err:
                 raise SysrepoException(
                     _("unable to write crypto.txt file: {0}").format(err))

--- a/src/tests/cli/t_pkg_contents.py
+++ b/src/tests/cli/t_pkg_contents.py
@@ -20,7 +20,7 @@
 # CDDL HEADER END
 #
 
-# Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2008, 2022, Oracle and/or its affiliates.
 
 from . import testutils
 if __name__ == "__main__":
@@ -229,6 +229,23 @@ class TestPkgContentsBasics(pkg5unittest.SingleDepotTestCase):
 
                 self.pkg("contents -o noodles -o mice nopathA nopathB")
                 self.assertTrue(nofield_plural in self.errout)
+
+        def test_contents_dash_t(self):
+                """Test the -t option of contents. When pkg contents doesn't
+                find any actions that match the specified action, we produce
+                appropriate error messages."""
+
+                self.image_create(self.rurl)
+                self.pkg("install nopathA")
+
+                # Test that the pkg has a license action
+                self.pkg("contents -t license nopathA", exit=0)
+
+                # Test that the pkg has a no depend action, and we produce
+                # appropriate error
+                self.pkg("contents -t depend nopathA")
+                self.assertFalse("contains no actions specified using the -t option"
+                    in self.output)
 
         def test_bug_4315(self):
                 """Test that when multiple manifests are given and -m is used,

--- a/src/tests/cli/t_pkg_image_update.py
+++ b/src/tests/cli/t_pkg_image_update.py
@@ -20,7 +20,7 @@
 # CDDL HEADER END
 #
 
-# Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2008, 2022, Oracle and/or its affiliates.
 
 from . import testutils
 if __name__ == "__main__":
@@ -170,6 +170,21 @@ class NoTestImageUpdate(pkg5unittest.ManyDepotTestCase):
             close
         """
 
+        obsolete = """
+            open goingaway@1.0
+            add dir mode=0755 owner=root group=bin path=/lib
+            close
+            open goingaway@2.0
+            add set name=pkg.obsolete value=true
+            close
+            open moreoldstuff@1.0
+            add dir mode=0755 owner=root group=bin path=/lib
+            close
+            open moreoldstuff@2.0
+            add set name=pkg.obsolete value=true
+            close
+        """
+
         def setUp(self):
                 # Two repositories are created for test2.
                 pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test2",
@@ -182,7 +197,8 @@ class NoTestImageUpdate(pkg5unittest.ManyDepotTestCase):
                 self.rurl6 = self.dcs[6].get_repo_url()
                 self.pkgsend_bulk(self.rurl1, (self.foo10, self.foo11,
                     self.baz11, self.qux10, self.qux11, self.quux10,
-                    self.quux11, self.corge11, self.incorp10, self.incorp11))
+                    self.quux11, self.corge11, self.incorp10, self.incorp11,
+                    self.obsolete))
 
                 self.pkgsend_bulk(self.rurl2, (self.foo10, self.bar10,
                     self.bar11, self.baz10, self.qux10, self.qux11,
@@ -335,7 +351,7 @@ class NoTestImageUpdate(pkg5unittest.ManyDepotTestCase):
 
         def test_nothingtodo(self):
                 """Test that if we have multiple facets of equal length that
-                we don't accidently report that there are image updates when
+                we don't accidentally report that there are image updates when
                 there are not."""
 
                 facet_max = 1000
@@ -483,6 +499,25 @@ class NoTestImageUpdate(pkg5unittest.ManyDepotTestCase):
                     "{0}".format(self.img_path(1)))
                 self.pkg("update -nv", exit=4)
 
+        def test_display_removed_pkgs(self):
+            """Verify that the names of removed packages are displayed during
+            upgrade."""
+
+            self.image_create(self.rurl1)
+            self.pkg("install foo@1.0 goingaway@1.0 moreoldstuff@1.0")
+            self.pkg("update", exit=0)
+
+            # Check the header and the package names without a version are
+            # present.
+            # Ensure that a package that has not been obsoleted is not included.
+            self.assertTrue("Removed Packages:" in self.output)
+
+            self.assertTrue("goingaway" in self.output)
+            self.assertFalse("goingaway@" in self.output)
+            self.assertTrue("moreoldstuff" in self.output)
+            self.assertFalse("moreoldstuff@" in self.output)
+
+            self.assertFalse("foo" in self.output)
 
 class TestIDROps(pkg5unittest.SingleDepotTestCase):
 

--- a/src/tests/cli/t_pkg_sysrepo.py
+++ b/src/tests/cli/t_pkg_sysrepo.py
@@ -31,6 +31,7 @@ if __name__ == "__main__":
 import pkg5unittest
 
 import copy
+import glob
 import os
 import shutil
 import six
@@ -512,12 +513,19 @@ test4\ttrue\ttrue\ttrue\t\t\t\t
                 if os.path.isdir(self.htdocs_dir):
                         shutil.rmtree(self.htdocs_dir)
                 shutil.copytree(base_dir, self.htdocs_dir)
-                crypto_path = os.path.join(self.common_config_dir, "crypto.txt")
-                if os.path.exists(crypto_path):
-                        os.chmod(crypto_path, 0o600)
-                shutil.copy(os.path.join(self.test_root, "apache-conf", name,
-                    "crypto.txt"), self.common_config_dir)
-                os.chmod(crypto_path, 0o400)
+
+                # We can have multiple crypto conf files
+                cred_path = os.path.join(self.test_root, "apache-conf", name)
+                cred_files = glob.glob(os.path.join(cred_path,
+                    "proxy-creds-*.pem"))
+                for cred_file in cred_files:
+                        destfile = os.path.join(self.common_config_dir,
+                            os.path.basename(cred_file))
+                        if os.path.exists(destfile):
+                                os.chmod(destfile, 0o600)
+                        shutil.copy(cred_file, self.common_config_dir)
+                        os.chmod(destfile, 0o400)
+
                 st = os.stat(base_dir)
                 uid = st.st_uid
                 gid = st.st_gid

--- a/src/util/apache2/depot/depot_httpd_ssl_protocol.conf
+++ b/src/util/apache2/depot/depot_httpd_ssl_protocol.conf
@@ -5,11 +5,11 @@
 # These are the available protocols:
 # SSLv2, SSLV3, TLSv1, TLSv1.1, TLS1.2, All
 #
-# SSLv2 and SSLv3 are disabled by default for security reasons.
+# SSLv3, TLSv1, TLSv1.1 are disabled by default for security reasons.
 # If you want to change default settings, please refer to the
 # Apache 2.2 documentation:
 # http://httpd.apache.org/docs/2.2/mod/mod_ssl.html#sslprotocol
 #
 
-SSLProtocol All -SSLv2 -SSLv3
+SSLProtocol +TLSv1.2 -SSLv3
 

--- a/src/util/apache2/sysrepo/sysrepo_httpd.conf.mako
+++ b/src/util/apache2/sysrepo/sysrepo_httpd.conf.mako
@@ -358,7 +358,6 @@ AllowEncodedSlashes On
 ProxyRequests On
 
 SSLProxyEngine on
-SSLProxyMachineCertificateFile ${sysrepo_runtime_dir}/crypto.txt
 SSLProxyProtocol all
 
 <Proxy *>
@@ -377,6 +376,23 @@ SSLProxyProtocol all
 # to be substrings of another URI.
 #
 </%doc>
+
+
+# It is possible that a remote SSL publisher may not send a CA name back to
+# identify the key/cert pair to use. 'mod_ssl', in this instance will use the
+# first key/cert in the <SSLProxyMachineCertificateFile> but depending upon
+# the order of the configured publishers it could be wrong. So workaround
+# this behavior by specifying a file per publisher.
+% for uri in reversed(sorted(uri_pub_map.keys())):
+       % for pub, cert_path, key_path, hash, proxy, utype in uri_pub_map[uri]:
+                % if uri.startswith("https:"):
+                        <Proxy "${uri}">
+                            SSLProxyMachineCertificateFile ${sysrepo_runtime_dir}/proxy-creds-${pub}.pem
+                            Require local
+                        </Proxy>
+                % endif
+        % endfor pub
+% endfor uri
 
 % for uri in reversed(sorted(uri_pub_map.keys())):
         % for pub, cert_path, key_path, hash, proxy, utype in uri_pub_map[uri]:


### PR DESCRIPTION
Two notable behaviour changes here:

1. Up to 5 packages which are being removed will be displayed during operations (including explicit `pkg uninstall`!) - I can see the use for the `update` case and maybe others like `autoremove` but `uninstall` seems a bit strange. There's a bug here when exactly 5 packages are removed (see below - it says there are 0 additional packages and that should not be displayed at all), I'll fix that.
2. When the target of an active mediator is uninstalled, there's a warning and if a new BE was created then it will not be activated.

```
bloody:pkg5:cup% pkg mediator python
MEDIATOR   VER. SRC. VERSION IMPL. SRC. IMPLEMENTATION
python     local     2       system
bloody:pkg5:cup% pfexec pkg uninstall python-27 illumos-tools developer/omnios-build-tools ooce/omnios-build-tools extra-build-tools
            Packages to remove:  5
            Services to change:  1
       Create boot environment: No
Create backup boot environment: No

Removed Packages:

  ooce/extra-build-tools
  ooce/omnios-build-tools
  developer/illumos-tools
  developer/omnios-build-tools
  runtime/python-27
  ...
  0 additional removed packages. Use 'pkg history' to view the full list.

PHASE                                          ITEMS
Removing old actions                       2262/2262
Updating package state database                 Done
Updating package cache                           5/5
Updating image state                            Done
Creating fast lookup database                   Done
Reading search index                            Done
Updating search index                            5/5

pkg: The following mediated link targets do not exist, please reset the links via pkg set-mediator:
  MEDIATOR                 REMOVED PATH(S)
  python                   usr/bin/python2.7, usr/bin/python2.7-config
```

and with a new BE:

```
The running system has not been modified. Modifications were only made to a clone (xxx) of the running system. This clone is mounted at /tmp/tmp_m12uo42 should you wish to inspect it.
pkg: The following mediated link targets do not exist, please reset the links via pkg set-mediator:
  MEDIATOR                 REMOVED PATH(S)
  python                   usr/bin/python2.7-config, usr/bin/python2.7
```