### PR TITLE
Fix invalid escape sequence

### DIFF
--- a/src/modules/flavor/python.py
+++ b/src/modules/flavor/python.py
@@ -87,7 +87,7 @@ class PythonSyntaxError(base.DependencyAnalysisError):
                     # Error text is after the last ']'
                     self.txt = msg[msg.index(']') + 2:]
                     # Extract the lineno and column from the [lineno:column]
-                    values = re.search("\[(.+):(.+)\]",msg)
+                    values = re.search(r"\[(.+):(.+)\]", msg)
                     self.line = values.group(1)
                     self.col = values.group(2)
 


### PR DESCRIPTION
Following f03c94c5abd5678e2cdf630a3f8d9af6c1045ddc
```
The file to be installed at usr/lib/python3.10/vendor-packages/pkg/flavor/python.py appears to be a python file but contains a syntax error that prevents it from being analyzed.  The text of the file can be found at /build/tmp/pkg-omni-r151041/pkg-omni-r151041/pkg/proto/root_i386/usr/lib/python3.10/vendor-packages/pkg/flavor/python.py.  The error happened on line 90 at offset 40. The problem was:
invalid escape sequence '\[' (python.py, line 90)
*** Error code 1
make: Fatal error: Command failed for target `pkgtmp/package:pkg.dep'
```