### PR TITLE
Provide exclude-policy to control what happens when actions match image exclusions.

### DIFF
--- a/src/brand/sparse/pkgcreatezone
+++ b/src/brand/sparse/pkgcreatezone
@@ -178,6 +178,7 @@ lc_pkg copy-publishers-from $GZ_IMAGE || fail_incomplete "$f_img"
 lc_pkg add-property-value exclude-patterns 'usr/(?!lib/fm)'
 lc_pkg add-property-value exclude-patterns 'sbin/'
 lc_pkg add-property-value exclude-patterns 'lib/(?!svc)'
+lc_pkg set-property exclude-policy ignore
 for ov in $overlays; do
     mp=${ov#*:}
     lc_pkg add-property-value key-files "$mp/.org.opensolaris,pkgkey"
@@ -238,6 +239,8 @@ cp /etc/default/{login,su} $ZONEROOT/etc/default/
 if [ -x /usr/lib/brand/$ZONEBRAND/postinstall ]; then
 	/usr/lib/brand/$ZONEBRAND/postinstall $ZONEROOT
 fi
+
+lc_pkg set-property exclude-policy reject
 
 printf "$m_complete\n\n" ${SECONDS}
 

--- a/src/client.py
+++ b/src/client.py
@@ -1052,6 +1052,15 @@ WARNING: The boot environment being modified is not the active one.
                 for a in plan.get_actions():
                         logger.info("  {0}".format(a))
 
+                seen = False
+                for (o, n) in plan.get_elided_actions():
+                        if not seen:
+                                logger.info("")
+                                logger.info(_(
+                                    "Elided due to image exclusions:"))
+                                seen = True
+
+                        logger.info(f'  {o} -> {n}')
 
         if plan.has_release_notes():
                 if need_blank:
@@ -1549,7 +1558,8 @@ def __api_execute_plan(operation, api_inst):
                 rval = EXIT_OOPS
         except (api_errors.InvalidPlanError,
             api_errors.ActionExecutionError,
-            api_errors.InvalidPackageErrors) as e:
+            api_errors.InvalidPackageErrors,
+            api_errors.PlanExclusionError) as e:
                 # Prepend a newline because otherwise the exception will
                 # be printed on the same line as the spinner.
                 error("\n" + str(e))
@@ -1701,7 +1711,8 @@ pkg:/package/pkg' as a privileged user and then retry the {op}."""
         if e_type in (api_errors.InvalidPlanError,
             api_errors.ReadOnlyFileSystemException,
             api_errors.ActionExecutionError,
-            api_errors.InvalidPackageErrors):
+            api_errors.InvalidPackageErrors,
+            api_errors.PlanExclusionError):
                 error("\n" + str(e), cmd=op)
                 return EXIT_OOPS
         if e_type == api_errors.ImageFormatUpdateNeeded:

--- a/src/man/pkg.1
+++ b/src/man/pkg.1
@@ -3575,7 +3575,35 @@ and should include a trailing
 .Pp
 Default value:
 .Sy []
-(empty list)
+.Pq empty list
+.\" exclude-policy
+.It Cm exclude-policy
+.Pq string
+Determine what happens when an execution plan attempts to deliver an action to
+an image when that action is excluded by the configured
+.Cm exclude-patterns
+property.
+The following values are allowed:
+.Bl -tag -width Ds
+.It Cm ignore
+Ignore excluded actions; the actions will not be delivered to the image.
+.It Cm warn
+Display a warning message, listing each action which has not been delivered to
+the image.
+.It Cm reject
+Reject the operation as an error, listing each action which matches the
+configured image exclusions, and is therefore preventing the operation.
+.El
+.Pp
+Default value:
+.Cm warn .
+.Pp
+NB: The
+.Sy sparse
+brand installer sets this property to
+.Cm reject
+for sparse zone images.
+.\" flush-content-cache-on-success
 .It Cm flush-content-cache-on-success
 .Pq boolean
 If this is set to
@@ -3607,7 +3635,7 @@ will refuse to perform update operations on the image.
 .Pp
 Default value:
 .Sy []
-(empty list)
+.Pq empty list
 .It Cm mirror-discovery
 .Pq boolean
 This property tells the client to discover link-local content mirrors using
@@ -4247,12 +4275,15 @@ Ignored if the
 .Fl C
 option is specified.
 .Pp
-When recursing into child images (usually installed
+When recursing into child images
+.Po usually installed
 .Sy lipkg ,
 .Sy sparse
 or
 .Sy pkgsrc
-branded non-global zones), update at most
+branded non-global zones
+.Pc ,
+update at most
 .Sy $PKG_CONCURRENCY
 child images in parallel.
 If

--- a/src/modules/client/api_errors.py
+++ b/src/modules/client/api_errors.py
@@ -234,6 +234,23 @@ class InvalidPackageErrors(ApiException):
                     "to invalid package metadata.  Details follow:\n\n"
                     "{0}").format("\n".join(str(e) for e in self.errors))
 
+class PlanExclusionError(ApiException):
+        """Used to indicate that the requested operation could not be executed
+        due to exclusions configured on the image."""
+
+        def __init__(self, paths):
+                self.paths = paths
+
+        def __str__(self):
+                return "{0}\n\n    {1}\n\n{2}".format(
+                    _("""\
+The files listed below match exclusions which are configured
+on this image and can therefore not be installed:"""),
+                    "\n    ".join(list(self.paths)),
+                    _("""\
+See the 'exclude-patterns' and 'exclude-policy' image properties in pkg(1) for
+more information.""")
+                )
 
 class LicenseAcceptanceError(ApiException):
         """Used to indicate that license-related errors occurred during

--- a/src/modules/client/client_api.py
+++ b/src/modules/client/client_api.py
@@ -995,7 +995,8 @@ def __api_execute_plan(operation, api_inst):
                 rval = __prepare_json(EXIT_OOPS, errors=errors_json)
         except (api_errors.InvalidPlanError,
             api_errors.ActionExecutionError,
-            api_errors.InvalidPackageErrors) as e:
+            api_errors.InvalidPackageErrors,
+            api_errors.PlanExclusionError) as e:
                 # Prepend a newline because otherwise the exception will
                 # be printed on the same line as the spinner.
                 _error_json("\n" + str(e), errors_json=errors_json)
@@ -1176,6 +1177,7 @@ pkg:/package/pkg' as a privileged user and then retry the {op}."""
             api_errors.NonLeafPackageException,
             api_errors.ReadOnlyFileSystemException,
             api_errors.InvalidPlanError,
+            api_errors.PlanExclusionError,
             api_errors.ActionExecutionError,
             api_errors.InvalidPackageErrors,
             api_errors.ImageBoundaryErrors,

--- a/src/modules/client/imageconfig.py
+++ b/src/modules/client/imageconfig.py
@@ -65,6 +65,7 @@ SEND_UUID = "send-uuid"
 USE_SYSTEM_REPO = "use-system-repo"
 CHECK_CERTIFICATE_REVOCATION = "check-certificate-revocation"
 EXCLUDE_PATTERNS = "exclude-patterns"
+EXCLUDE_POLICY = "exclude-policy"
 KEY_FILES = "key-files"
 DEFAULT_RECURSE = "default-recurse"
 DEFAULT_CONCURRENCY = "recursion-concurrency"
@@ -81,6 +82,7 @@ default_policies = {
     USE_SYSTEM_REPO: False,
     DEFAULT_RECURSE: False,
     TEMP_BE_ACTIVATION: False,
+    EXCLUDE_POLICY: "warn",
 }
 
 default_policy_map = {
@@ -205,6 +207,9 @@ class ImageConfig(cfg.FileConfig):
                             CHECK_CERTIFICATE_REVOCATION]),
                     cfg.PropList("dehydrated"),
                     cfg.PropList(EXCLUDE_PATTERNS),
+                    cfg.PropDefined(EXCLUDE_POLICY,
+                        allowed=["ignore", "warn", "reject"],
+                        default=default_policies[EXCLUDE_POLICY]),
                     cfg.PropList(KEY_FILES),
                     cfg.PropBool(DEFAULT_RECURSE,
                         default=default_policies[DEFAULT_RECURSE]),

--- a/src/modules/client/plandesc.py
+++ b/src/modules/client/plandesc.py
@@ -42,6 +42,7 @@ import collections
 import itertools
 import operator
 import six
+from typing import Iterator
 
 import pkg.actions
 import pkg.client.actuator
@@ -148,6 +149,7 @@ class PlanDescription(object):
             "children_nop": [ li.LinkedImageName ],
             "children_planned": [ li.LinkedImageName ],
             "install_actions": [ _ActionPlan ],
+            "elided_actions": [ _ActionPlan ],
             "li_pfacets": pkg.facet.Facets,
             "li_ppkgs": frozenset([ pkg.fmri.PkgFmri ]),
             "li_props": { li.PROP_NAME: li.LinkedImageName },
@@ -210,6 +212,7 @@ class PlanDescription(object):
                 self.removal_actions = []
                 self.update_actions = []
                 self.install_actions = []
+                self.elided_actions = []
                 # smf and other actuators (driver actions get added during
                 # execution stage).
                 self._actuators = pkg.client.actuator.Actuator()
@@ -652,6 +655,10 @@ class PlanDescription(object):
                     self.install_actions):
                 # pylint: enable=W0612
                         yield "{0} -> {1}".format(o_act, d_act)
+
+        def get_elided_actions(self) -> Iterator[tuple[object, object]]:
+                for pplan, o_act, d_act in self.elided_actions:
+                        yield (o_act, d_act)
 
         def has_release_notes(self):
                 """True if there are release notes for this plan"""

--- a/src/tests/cli/t_pkg_property.py
+++ b/src/tests/cli/t_pkg_property.py
@@ -174,8 +174,9 @@ class TestPkgPropertyBasics(pkg5unittest.SingleDepotTestCase):
                 self.pkg("add-property-value exclude-patterns 'usr/(?!lib/fm)'")
                 self.pkg("add-property-value exclude-patterns 'sbin/'")
 
+                self.pkg("set-property exclude-policy ignore")
                 self.pkg("install xpkg")
-
+                self.assertTrue("libbarney.so" not in self.output);
                 self.assert_files_exist((
                     ("bambam", True),
                     ("sbin/dino", False),
@@ -184,7 +185,20 @@ class TestPkgPropertyBasics(pkg5unittest.SingleDepotTestCase):
                     ("usr/lib/fm/wilma.xml", True),
                     ("usr/lib/fm/betty.xml", True),
                 ))
+                self.pkg("uninstall xpkg")
 
+                self.pkg("set-property exclude-policy warn")
+                self.pkg("install xpkg")
+                self.assertTrue("actions have not been installed" in
+                    self.output);
+                self.assertTrue("configured exclusions" in self.output)
+                self.assertTrue("libbarney.so" in self.output)
+                self.pkg("uninstall xpkg")
+
+                self.pkg("set-property exclude-policy reject")
+                self.pkg("install xpkg", exit=1)
+                self.assertTrue("match exclusions which" in self.errout)
+                self.assertTrue("libbarney.so" in self.errout)
 
 if __name__ == "__main__":
         unittest.main()


### PR DESCRIPTION
This is a work in progress for #401.

In this state, a new warning is presented whenever some actions are elided from the plan due to exclusions configured on the image. A sparse zone is just one type of image which has exclusions, and the exclusion functionality of pkg is a generic one, so this is what I've come up with so far:

```
% pkg property
PROPERTY                       VALUE
exclude-patterns               ['usr/share/isc-dhcp']

% pfexec python3 =pkg install -nv isc-dhcp

******************************************************************************
WARNING: The following actions will not be installed as this is a partial
         image (there are configured exclusions).

        /usr/share/isc-dhcp
        /usr/share/isc-dhcp/examples
        /usr/share/isc-dhcp/examples/dhcpd.conf.example
******************************************************************************


           Packages to install:        1
            Services to change:        7
     Estimated space available: 69.51 GB
Estimated space to be consumed: 36.67 MB
...
```

The original bug reporter suggested that this could also be an error, with a flag to override.

Comments and suggestions welcome.