### PR TITLE
Add support for UEFI media path boot entries

### DIFF
--- a/src/man/bhyve.7
+++ b/src/man/bhyve.7
@@ -68,6 +68,15 @@ For the UEFI bootrom, the available options are:
 .Bl -tag -width bootdisk -offset 4n
 .It Cm shell
 The UEFI firmware shell.
+.It Cm path Ns Oo Ar N Oc
+The
+.Ar N Ns th
+boot entry that specifies a specific boot media path.
+The first such entry is selected with
+.Cm path
+or
+.Cm path0
+and subsequent ones use increasing suffixes.
 .It Cm bootdisk
 The disk defined using the
 .Ic bootdisk
@@ -105,18 +114,18 @@ These must be used alone, without any additional options:
 .It Cm cd
 Legacy alias for
 .Sm off
-.Ic bootdisk , cdrom .
+.Ic path0 , bootdisk , cdrom0
 .Sm on
 .It Cm dc
 Legacy alias for
 .Sm off
-.Ic cdrom , bootdisk .
+.Ic cdrom0 , path0 , bootdisk
 .Sm on
 .El
 .Pp
 Default value:
 .Sm off
-.Ic bootdisk , cdrom
+.Ic path0, bootdisk , cdrom0
 .Sm on
 .Pp
 Example:


### PR DESCRIPTION
Some guests use a non-standard boot path and create their own boot entry for this:

```
BOOT OPTIONS
------------
Bootorder: [9, 0, 1, 2, 3, 4, 5, 6, 7]
  H [0 ] UiApp - [App 462caa21-7614-4503-836e-8ab6f4662331]
    [1 ] UEFI BHYVE SATA DVD ROM BHYVE-BD80-94E5-3155 - [PCI 29.0]
    [2 ] UEFI Misc Device - [PCI 4.0]
    [3 ] UEFI Misc Device 2 - [PCI 5.0]
    [4 ] UEFI BHYVE SATA DISK BHYVE-0FEB-9A35-9220 - [PCI 5.2]
    [5 ] UEFI PXEv4 (MAC:0208203E3809) - [PCI 6.0]
    [6 ] UEFI HTTPv4 (MAC:0208203E3809) - [PCI 6.0] [HTTP]
    [7 ] EFI Internal Shell - [App 7c04a583-9e3e-4f1c-ad65-e05268d0b4d1]
    [8 ] EFI Internal Shell - [App 7c04a583-9e3e-4f1c-ad65-e05268d0b4d1]
C   [9 ] Fedora - [Path \EFI\fedora\shimx64.efi]
C    - Current (first in boot order)
 N   - Next Boot
  H  - Hidden
```