### PR TITLE
elf: Understand aarch64 kernel paths, and don't redirect user paths to /64

### DIFF
--- a/src/modules/flavor/elf.py
+++ b/src/modules/flavor/elf.py
@@ -221,12 +221,14 @@ def process_elf_dependencies(action, pkg_vars, dyn_tok_conv, run_paths,
                                 kernel64 = "amd64"
                         elif ei["arch"] == "sparc":
                                 kernel64 = "sparcv9"
+                        elif ei["arch"] == "aarch64":
+                                kernel64 = "aarch64"
                         else:
                                 raise RuntimeError("Unknown arch:{0}".format(
                                     ei["arch"]))
         else:
                 for p in default_run_paths:
-                        if ei["bits"] == 64:
+                        if ei["bits"] == 64 and ei["arch"] != "aarch64":
                                 p += "/64"
                         if p not in rp:
                                 rp.append(p)


### PR DESCRIPTION
This matches the current setup with the arm64 project, and is sufficient to let us use pkgdepend(1) there (with a handful of further fixes on the illumos side.

The test suite run is still in progress (I spent a lot of time trying to pacify github)