### PR TITLE
Use separate python module requirements for aarch64

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -33,6 +33,8 @@ PYTESTS = $(PYVERSIONS:%=runtest/%)
 PYMODULES = $(PYVERSIONS:%=modules/%)
 TESTRESULTS = $(PYVERSIONS:%=testresults/%)
 
+REQUIREMENTS = requirements.txt
+
 all := TARGET = all
 build := TARGET = build
 install := TARGET = install
@@ -70,7 +72,7 @@ $(PYVERSIONS): FRC
 
 $(PYMODULES): FRC
 	../tools/installmodules $(CODE_WS) $(ROOT) $(@F) \
-	    $(TARGET) $(ROOTPKGLIB) core requirements.txt
+	    $(TARGET) $(ROOTPKGLIB) core $(REQUIREMENTS)
 
 $(PYTESTS): $(PYMODULES)
 	-pfexec python$(@F) tests/run.py -t -j $(JOBS)

--- a/src/requirements-aarch64.txt
+++ b/src/requirements-aarch64.txt
@@ -1,0 +1,28 @@
+#
+# This file was automatically produced by tools/updatereqs
+# Generated on Tue May  9 08:31:46 UTC 2023
+# Do not edit directly
+#
+autocommand==2.2.2
+cheroot==9.0.0
+CherryPy==18.8.0
+inflect==6.0.4
+jaraco.collections==4.1.0
+jaraco.context==4.3.0
+jaraco.functools==3.6.0
+jaraco.text==3.11.1
+Mako==1.2.4
+MarkupSafe==2.1.2
+more-itertools==9.1.0
+ply==3.11
+portend==3.1.0
+prettytable==3.7.0
+pybonjour @ https://mirrors.omnios.org/pymodules/pybonjour/pybonjour-1.1.1-python3.tar.gz#sha256
+pycurl==7.44.1 # stuck on 7.44.1 - https://github.com/pycurl/pycurl/issues/748
+pydantic==1.10.7
+pytz==2023.3
+six==1.16.0
+tempora==5.2.2
+typing_extensions==4.5.0
+wcwidth==0.2.6
+zc.lockfile==3.0.post1


### PR DESCRIPTION
More and more python modules are starting to require rust to
build and rust is not yet available for aarch64 (although
work is ongoing there). Use a separate requirements list for
aarch64 which installs older module versions, from a time
before the python/rust mashup.
