### PR TITLE
Update requirements to allow the test suite to run again.

### DIFF
--- a/src/brand/bhyve/requirements.txt
+++ b/src/brand/bhyve/requirements.txt
@@ -1,7 +1,7 @@
 #
 # This file was automatically produced by tools/updatereqs
-# Generated on Wed Jun 15 20:07:44 UTC 2022
+# Generated on February 15, 2024 at 02:31:17 PM UTC
 # Do not edit directly
 #
-construct==2.10.68
-PyYAML==6.0
+construct==2.10.70
+PyYAML==6.0.1

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,29 +1,29 @@
 #
 # This file was automatically produced by tools/updatereqs
-# Generated on Sun Mar  5 16:37:23 UTC 2023
+# Generated on February 15, 2024 at 02:31:10 PM UTC
 # Do not edit directly
 #
+annotated-types==0.6.0
 autocommand==2.2.2
-cheroot==9.0.0
-CherryPy==18.8.0
-inflect==6.0.2
-jaraco.classes==3.2.3
-jaraco.collections==3.8.0
+cheroot==10.0.0
+CherryPy==18.9.0
+inflect==7.0.0
+jaraco.collections==5.0.0
 jaraco.context==4.3.0
-jaraco.functools==3.6.0
-jaraco.text==3.11.1
-Mako==1.2.4
-MarkupSafe==2.1.2
-more-itertools==9.1.0
+jaraco.functools==4.0.0
+jaraco.text==3.12.0
+Mako==1.3.2
+MarkupSafe==2.1.5
+more-itertools==10.2.0
 ply==3.11
-portend==3.1.0
-prettytable==3.6.0
-pybonjour @ https://mirrors.omnios.org/pymodules/pybonjour/pybonjour-1.1.1-python3.tar.gz
+portend==3.2.0
+prettytable==3.9.0
+pybonjour @ https://mirrors.omnios.org/pymodules/pybonjour/pybonjour-1.1.1-python3.tar.gz#sha256
 pycurl==7.44.1 # stuck on 7.44.1 - https://github.com/pycurl/pycurl/issues/748
-pydantic==1.10.5
-pytz==2022.7.1
-six==1.16.0
-tempora==5.2.1
-typing_extensions==4.5.0
-wcwidth==0.2.6
+pydantic==2.6.1
+pydantic_core==2.16.2
+pytz==2024.1
+tempora==5.5.0
+typing_extensions==4.9.0
+wcwidth==0.2.13
 zc.lockfile==3.0.post1


### PR DESCRIPTION
While attempting to run the test suite for r46 I hit the following issue:
```
  Downloading PyYAML-6.0.tar.gz (124 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 125.0/125.0 kB 5.5 MB/s eta 0:00:00
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [54 lines of output]
      running egg_info
      writing lib/PyYAML.egg-info/PKG-INFO
      writing dependency_links to lib/PyYAML.egg-info/dependency_links.txt
      writing top-level names to lib/PyYAML.egg-info/top_level.txt
      Traceback (most recent call last):
        File "/tmp/tmp_36.r7n/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/tmp/tmp_36.r7n/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/tmp_36.r7n/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-rto459kq/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=['wheel'])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-rto459kq/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-rto459kq/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 311, in run_setup
          exec(code, locals())
        File "<string>", line 288, in <module>
        File "/tmp/pip-build-env-rto459kq/overlay/lib/python3.11/site-packages/setuptools/__init__.py", line 103, in setup
          return distutils.core.setup(**attrs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-rto459kq/overlay/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 185, in setup
          return run_commands(dist)
                 ^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-rto459kq/overlay/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
          dist.run_commands()
        File "/tmp/pip-build-env-rto459kq/overlay/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
          self.run_command(cmd)
        File "/tmp/pip-build-env-rto459kq/overlay/lib/python3.11/site-packages/setuptools/dist.py", line 963, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-rto459kq/overlay/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
          cmd_obj.run()
        File "/tmp/pip-build-env-rto459kq/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 321, in run
          self.find_sources()
        File "/tmp/pip-build-env-rto459kq/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 329, in find_sources
          mm.run()
        File "/tmp/pip-build-env-rto459kq/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 550, in run
          self.add_defaults()
        File "/tmp/pip-build-env-rto459kq/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 588, in add_defaults
          sdist.add_defaults(self)
        File "/tmp/pip-build-env-rto459kq/overlay/lib/python3.11/site-packages/setuptools/command/sdist.py", line 102, in add_defaults
          super().add_defaults()
        File "/tmp/pip-build-env-rto459kq/overlay/lib/python3.11/site-packages/setuptools/_distutils/command/sdist.py", line 251, in add_defaults
          self._add_defaults_ext()
        File "/tmp/pip-build-env-rto459kq/overlay/lib/python3.11/site-packages/setuptools/_distutils/command/sdist.py", line 336, in _add_defaults_ext
          self.filelist.extend(build_ext.get_source_files())
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "<string>", line 204, in get_source_files
        File "/tmp/pip-build-env-rto459kq/overlay/lib/python3.11/site-packages/setuptools/_distutils/cmd.py", line 107, in __getattr__
          raise AttributeError(attr)
      AttributeError: cython_sources
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
*** Error code 1
make: Fatal error: Command failed for target `modules/3.11'
Current working directory /root/src/pkg5/src/brand/bhyve
*** Error code 1
The following command caused the error:
cd bhyve; pwd; make install
make: Fatal error: Command failed for target `bhyve'
Current working directory /root/src/pkg5/src/brand
*** Error code 1
The following command caused the error:
cd brand; pwd; make install CC=/usr/bin/gcc-12
make: Fatal error: Command failed for target `brand'
```

To remedy this I ran `tools/updatereqs`.  This PR is a diff of what packages were updated - with this diff in place I was able to successfully run the test suite.