### PR TITLE
Support resolving cross dependencies

### DIFF
--- a/src/modules/flavor/depthlimitedmf.py
+++ b/src/modules/flavor/depthlimitedmf.py
@@ -3,6 +3,7 @@
 # Software Foundation; All Rights Reserved
 #
 # Copyright (c) 2012, 2022, Oracle and/or its affiliates.
+# Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
 
 
 """A standalone version of ModuleFinder which limits the depth of exploration
@@ -66,9 +67,21 @@ class ModuleInfo(object):
                 "64/{0}module.so",
             ]
         else:
-            self.patterns += [
-                "{{0}}{0}".format(s) for s in EXTENSION_SUFFIXES
-            ] + ["64/{{0}}{0}".format(s) for s in EXTENSION_SUFFIXES]
+            try:
+                cross_env = os.environ["PKG_CROSS_DEPEND"]
+                suffixes = []
+                for s in EXTENSION_SUFFIXES:
+                    if s.endswith("solaris2.so"):
+                        s = "{}-{}.so".format(
+                            "-".join(s.split("-")[:2]), cross_env
+                        )
+                    suffixes.append(s)
+                self.patterns += ["{{0}}{0}".format(s) for s in suffixes]
+            except KeyError:
+                suffixes = EXTENSION_SUFFIXES
+                self.patterns += ["{{0}}{0}".format(s) for s in suffixes] + [
+                    "64/{{0}}{0}".format(s) for s in suffixes
+                ]
         self.dirs = sorted(dirs)
 
     def make_package(self):


### PR DESCRIPTION
Now that python 3.12 has been fixed so that it properly detects the
host triple, shared objects include this triple in the filename.
This means that the filename search list for a module called `foo` is
now:
```
        pkg.debug.depend.file=64/foo.abi3.so
        pkg.debug.depend.file=64/foo.cpython-312-x86_64-pc-solaris2.so
        pkg.debug.depend.file=64/foo.so
        pkg.debug.depend.file=foo.abi3.so
        pkg.debug.depend.file=foo.cpython-312-x86_64-pc-solaris2.so
        pkg.debug.depend.file=foo.py
        pkg.debug.depend.file=foo.pyc
        pkg.debug.depend.file=foo.pyo
        pkg.debug.depend.file=foo.so
        pkg.debug.depend.file=foo/__init__.py
```
This obviously doesn't work for aarch64, and we were effectively
getting away with it before because the shared objects were just named
`foo.cpython-312.so`. With this patch, if the environment contains
```
        PKG_CROSS_DEPEND=aarch64-unknown-solaris2
```
the search list is:
```
        pkg.debug.depend.file=foo.abi3.so
        pkg.debug.depend.file=foo.cpython-312-aarch64-unknown-solaris2.so
        pkg.debug.depend.file=foo.py
        pkg.debug.depend.file=foo.pyc
        pkg.debug.depend.file=foo.pyo
        pkg.debug.depend.file=foo.so
        pkg.debug.depend.file=foo/__init__.py
```
Note also that the 64/ paths have been removed for cross targets.