### PR TITLE
Determine BUILDNUM from os-release

### DIFF
--- a/src/pkg/Makefile
+++ b/src/pkg/Makefile
@@ -28,7 +28,8 @@ include ../Makefile.com
 PKGVERS_COMPONENT = 0.5.11
 PKGVERS_BUILTON   = 5.11
 BUILDNUM.cmd      = \
-	nawk '$$1 == "OmniOS" { print $$3 }' /etc/release | tr -d '[a-z]'
+	awk -F= '$$1 == "BUILD_ID" { split($$2, a, "."); print a[1] }' \
+	/etc/os-release
 BUILDNUM          = $(BUILDNUM.cmd:sh)
 UPDATENUM         = 0
 SRUNUM            = 0


### PR DESCRIPTION
`/etc/os-release` is a better reference than parsing `/etc/release` and using tricks like `tr` to remove the trailing release letter(s).