### PR TITLE
Add synthetic pkg.fmri.name attribute to pkgmogrify

### DIFF
--- a/src/man/pkgmogrify.1
+++ b/src/man/pkgmogrify.1
@@ -1,6 +1,6 @@
 .\" Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
-.\" Copyright 2022 OmniOS Community Edition (OmniOSce) Association.
-.Dd February 17, 2022
+.\" Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
+.Dd October 1, 2024
 .Dt PKGMOGRIFY 1
 .Os
 .Sh NAME
@@ -309,6 +309,15 @@ action, or it is treated as
 described above.
 When the processing reaches the end of the manifest file describing the
 package, the attributes are cleared for the next package.
+The following synthetic attributes are also automatically generated from
+.Sy pkg.fmri
+when it is encountered:
+.Bl -tag -width Ds
+.It Cm pkg.fmri.name
+The name of the package, without any scheme, publisher name or version
+information, e.g.
+.Sq library/libxml2 .
+.El
 .Pp
 It is useful not only to reference package attributes as if they were action
 attributes, but also to match on them, and even temporarily modify them.

--- a/src/modules/mogrify.py
+++ b/src/modules/mogrify.py
@@ -886,6 +886,11 @@ def process_mog(
                     pkg_attrs.setdefault(name, []).append(value)
                 else:
                     pkg_attrs.setdefault(name, []).extend(value)
+                if name == "pkg.fmri":
+                    pfmri = pkg.fmri.PkgFmri(value)
+                    pkg_attrs.setdefault("pkg.fmri.name", []).append(
+                        pfmri.get_name()
+                    )
             comment, a = apply_transforms(
                 transforms, act, pkg_attrs, verbose, filename, lineno
             )

--- a/src/tests/cli/t_pkgmogrify.py
+++ b/src/tests/cli/t_pkgmogrify.py
@@ -70,7 +70,7 @@ link path=usr/X11/lib/libXmu.so target=./libXmu.so.4
 """
 
     pkgcontents2 = """\
-set name=pkg.fmri value=wombat/heaven@1.0,5.11-0.101
+set name=pkg.fmri value=pkg://tp/wombat/heaven@1.0,5.11-0.101
 set name=bugs value=12345 value=54321 value=13524
 set name=justonebug value=12345
 file thisismyhashvalue path=usr/bin/foo mode=0777 owner=root group=bin
@@ -111,6 +111,7 @@ file NOHASH path=kernel/drv/common2 reboot-needed=true
         "exit7 on bobcat": "<transform file bobcat=1 -> exit 7>",
         "exit6 on bobcat": "<transform file bobcat=1 -> exit 6 found a bobcat>",
         "pkg.fmri": '<transform file path=usr/bin/foo -> print pkg attr "%{{pkg.fmri}}" and the rest>',
+        "pkg.fmri.name": '<transform file path=usr/bin/foo -> print pkg attr "%{{pkg.fmri.name}}" and the rest>',
         "pkg.bugs": '<transform file path=usr/bin/foo -> print pkg attr "%{{bugs}}" and the rest>',
         "fmrival": '<transform set name=pkg.fmri -> print test of "%(value)" ... or is it?>',
         "fmrinoval": '<transform set name=pkg.fmri -> print test of "%(valuee)" ... or is it?>',
@@ -527,7 +528,7 @@ file NOHASH path=kernel/drv/common2 reboot-needed=true
         # ... or an action ...
         self.pkgmogrify([self.transforms["emitaction"], source_file])
         self.assertMatch(
-            "^depend fmri=wombat/heaven@1.0,5.11-0.101 type=incorporate"
+            "^depend fmri=pkg://tp/wombat/heaven@1.0,5.11-0.101 type=incorporate"
         )
 
         # Recursive transforms shouldn't blow up.
@@ -550,7 +551,7 @@ file NOHASH path=kernel/drv/common2 reboot-needed=true
         source_file = os.path.join(self.test_root, "source_file2")
 
         expect = r'^test of "{0}" ... or is it\?$'
-        fmri = "wombat/heaven@1.0,5.11-0.101"
+        fmri = "pkg://tp/wombat/heaven@1.0,5.11-0.101"
 
         # Simple %() replacement
         self.pkgmogrify([self.transforms["fmrival"], source_file])
@@ -625,8 +626,11 @@ file NOHASH path=kernel/drv/common2 reboot-needed=true
         # Simple valued
         self.pkgmogrify([self.transforms["pkg.fmri"], source_file])
         self.assertMatch(
-            '^pkg attr "wombat/heaven@1.0,5.11-0.101" and ' "the rest$"
+            '^pkg attr "pkg://tp/wombat/heaven@1.0,5.11-0.101" and ' "the rest$"
         )
+
+        self.pkgmogrify([self.transforms["pkg.fmri.name"], source_file])
+        self.assertMatch('^pkg attr "wombat/heaven" and ' "the rest$")
 
         # List valued
         self.pkgmogrify([self.transforms["pkg.bugs"], source_file])


### PR DESCRIPTION
This would allow easier generation of things like per-package facets, e.g.:

```xml
<transform file elfbits=32 path=.*/lib.*\.so -> set facet.32bit.%{pkg.fmri.name} true>
```

The updated test suite passes.
