### PR TITLE
fix broken zone cloning due to OpenSSH DSA deprecation

### DIFF
--- a/src/brand/ipkg/system-unconfigure
+++ b/src/brand/ipkg/system-unconfigure
@@ -131,7 +131,7 @@ reset_ssh_config() {
             || bomb "Failed to update PermitRootLogin in $f"
     fi
     echo "------ Generating new ssh host keys"
-    for algo in rsa dsa; do
+    for algo in rsa ecdsa; do
         [ -f $ALTROOT/etc/ssh/ssh_host_${algo}_key ] \
             && mv $ALTROOT/etc/ssh/ssh_host_${algo}_key{,.old}
         [ -f $ALTROOT/etc/ssh/ssh_host_${algo}_key.pub ] \
@@ -140,8 +140,8 @@ reset_ssh_config() {
     /usr/bin/ssh-keygen -q -t rsa -b 2048 -N '' -C root@unknown \
         -f $ALTROOT/etc/ssh/ssh_host_rsa_key \
         || bomb "Failed to create new $ALTROOT/etc/ssh/ssh_host_rsa_key"
-    /usr/bin/ssh-keygen -q -t dsa -N '' -C root@unknown \
-        -f $ALTROOT/etc/ssh/ssh_host_dsa_key \
+    /usr/bin/ssh-keygen -q -t ecdsa -b 521 -N '' -C root@unknown \
+        -f $ALTROOT/etc/ssh/ssh_host_ecdsa_key \
         || bomb "Failed to create new $ALTROOT/etc/ssh/ssh_host_dsa_key"
     rm -f $ALTROOT/etc/ssh/ssh_host_*.old \
         || bomb "Failed to remove old key files"


### PR DESCRIPTION
Trying to clone a lipkg zone (and, I assume, any other brand) currently fails with 

```
ERROR: Zone unconfiguration failed
```

This is because the `system-unconfigure` script attempts to use `ssh-keygen` to generate a DSA key. DSA keys have been removed from OpenSSH, so the script errors.

This change creates an ECDSA key instead. Perhaps DSA was only ever in there for backward compatibility, so I leave it to the more knowledgeable reviewer to decide if a more correct fix would be to simply remove the DSA lines altogether.

I ran the test suite and had a few permissions-based failures (I don't have a proper OmniOS build env at the moment) but nothing which looked related to this change. 