### PR TITLE
Traceback when listing packages with empty fields

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -682,6 +682,8 @@ def calc_fmtstr(attrs, data):
 
     for entry in data:
         for i, field in enumerate(attrs):
+            if not entry.get(field):
+                continue
             if len(entry.get(field)) > widths[i]:
                 widths[i] = len(entry.get(field))
 


### PR DESCRIPTION

```
Traceback (most recent call last):
  File "/usr/bin/pkg", line 7797, in handle_errors
    __ret = func(*args, **kwargs)
            ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/bin/pkg", line 7782, in main_func
    return func(op=subcommand, api_inst=api_inst, pargs=pargs, **opts)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/bin/pkg", line 849, in list_inventory
    fmt_str = calc_fmtstr(attrs, data)
              ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/bin/pkg", line 648, in calc_fmtstr
    if len(entry.get(field)) > widths[i]:
       ^^^^^^^^^^^^^^^^^^^^^
TypeError: object of type 'NoneType' has no len()
```

