### PR TITLE
Fix elf extension division by zero with corrupt input

### DIFF
--- a/src/modules/elfextract.c
+++ b/src/modules/elfextract.c
@@ -21,7 +21,7 @@
 
 /*
  *  Copyright (c) 2009, 2023, Oracle and/or its affiliates.
- *  Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+ *  Copyright 2025 OmniOS Community Edition (OmniOSce) Association.
  */
 
 #include <libelf.h>
@@ -335,7 +335,8 @@ getdynamic(int fd)
 				goto bad;
 			}
 
-			num_dyn = shdr.sh_size / shdr.sh_entsize;
+			num_dyn = shdr.sh_entsize > 0 ?
+			    shdr.sh_size / shdr.sh_entsize : 0;
 			dynstr = shdr.sh_link;
 			break;
 


### PR DESCRIPTION
We found a core file from `pkgdepend` when processing a stripped
go binary (we know that stripping a go binary breaks them).

Here's the section from the input file that caused a SIGFPE due to
a division be zero.

```
Section Header[6]:  sh_name: .dynamic
    sh_addr:      0x2f58              sh_flags:   [ SHF_ALLOC ]
    sh_size:      0x70                sh_type:    [ SHT_DYNAMIC ]
    sh_offset:    0x2f58              sh_entsize: 0
    sh_link:      0                   sh_info:    0
    sh_addralign: 0x8
```

