### PR TITLE
introduce arch specific CFLAGS

### DIFF
--- a/src/Makefile.com
+++ b/src/Makefile.com
@@ -29,7 +29,9 @@ ROOTPKGLIB = $(ROOTUSRLIB)/pkg
 TRIPLET = x86_64-pc-solaris2
 
 CC = /usr/bin/gcc-14
-CFLAGS = -m64 -Wall -Werror -Wextra -gdwarf-2 -gstrict-dwarf \
+CFLAGS_i386 = -m64
+CFLAGS_aarch64 =
+CFLAGS = $(CFLAGS_$(MACH)) -Wall -Werror -Wextra -gdwarf-2 -gstrict-dwarf \
 	-fno-aggressive-loop-optimizations
 CPPFLAGS = -D_REENTRANT -D_POSIX_PTHREAD_SEMANTICS
 


### PR DESCRIPTION
OmniOS' `gcc` has been building 64-bit objects by default for a while. Remove the explicit `-m64` that will break the build for e.g. `aarch64`.