### PR TITLE
brand/bhyve: Add bootdiskif attribute

### DIFF
--- a/src/brand/bhyve/boot.py
+++ b/src/brand/bhyve/boot.py
@@ -466,8 +466,17 @@ for i, v in z.build_devlist('cdrom', 8):
 
 try:
     bootdisk = z.findattr('bootdisk')
+    if (bootdiskif := z.findattr('bootdiskif')) is not None:
+        bootdiskif = bootdiskif.get('value').strip()
+        try:
+            bootdiskif = aliases['diskif'][bootdiskif]
+        except KeyError:
+            pass
+    else:
+        bootdiskif = opts['diskif']
+
     args.extend([
-        '-s', '{0}:0,{1},{2}'.format(BOOTDISK_SLOT, opts['diskif'],
+        '-s', '{0}:0,{1},{2}'.format(BOOTDISK_SLOT, bootdiskif,
             diskpath(bootdisk.get('value').strip()))
     ])
     add_bootoption('bootdisk', None, ('pci', f'{BOOTDISK_SLOT}.0'))

--- a/src/man/bhyve.7
+++ b/src/man/bhyve.7
@@ -60,6 +60,17 @@ A suitable ZFS volume can be created using the
 command, for example:
 .Pp
 .Dl zfs create -V 30G rpool/bootdisk2
+.\" bootdiskif
+.It Ic bootdiskif Ar type
+.Pp
+Specifies the type of interface to which the boot disk will be attached.
+See the description of the
+.Ic diskif
+attribute for a list of available interface types.
+.Pp
+If unset, the value of the
+.Ic diskif
+attribute will be used.
 .\" bootorder
 .It Ic bootorder Ar option Ns Oo \&, Ns Ar option Ns \&... Oc
 .Pp


### PR DESCRIPTION
The bootdiskif attribute works exactly the same as diskif, but it applies only to the boot disk. For backwards compatibility, diskif will be used if if bootdiskif is unset.