### PR TITLE
brand/bhyve: Prevent long delays when shutting down unresponsive VMs

### DIFF
--- a/src/brand/bhyve/support
+++ b/src/brand/bhyve/support
@@ -21,13 +21,27 @@ bhyve_shutdown()
 {
 	typeset -i delay="${1:-60}"
 	log "Killing bhyve process - %d" $delay
-	pkill -z "$ZONENAME" bhyve
+	pkill -TERM -z "$ZONENAME" bhyve
 	while (( delay > 0 )) && pgrep -z "$ZONENAME" bhyve >/dev/null; do
 		((delay % 30 == 0)) && log "Waiting for bhyve to exit"
 		((delay = delay - 1))
 		sleep 1
 	done
 	log "bhyve shutdown done"
+}
+
+bhyve_halt()
+{
+	typeset -i force_halt=0
+	while pgrep -z "$ZONENAME" bhyve >/dev/null; do
+		force_halt=1
+		log "Force bhyve poweroff"
+		/usr/sbin/bhyvectl --vm=$ZONENAME --force-poweroff
+		sleep 5
+	done
+	if [ "$force_halt" -eq 1 ]; then
+		log "bhyve poweroff done"
+	fi
 }
 
 cmd="${1:?cmd}"; shift
@@ -50,7 +64,8 @@ case $cmd in
 		;;
 	    $ZONE_STATE_RUNNING:$ZONE_STATE_CMD_HALT)
 		# halting (even as part of rebooting)
-		bhyve_shutdown 1800
+		bhyve_shutdown 20
+		bhyve_halt
 		;;
 	esac
 	;;

--- a/src/brand/bhyve/support
+++ b/src/brand/bhyve/support
@@ -21,13 +21,32 @@ bhyve_shutdown()
 {
 	typeset -i delay="${1:-60}"
 	log "Killing bhyve process - %d" $delay
-	pkill -z "$ZONENAME" bhyve
+	pkill -TERM -z "$ZONENAME" bhyve
 	while (( delay > 0 )) && pgrep -z "$ZONENAME" bhyve >/dev/null; do
-		((delay % 30 == 0)) && log "Waiting for bhyve to exit"
+		((delay % 5 == 0)) && log "Waiting for bhyve to exit"
 		((delay = delay - 1))
 		sleep 1
 	done
 	log "bhyve shutdown done"
+}
+
+bhyve_halt()
+{
+	typeset -i force_halt=0
+	typeset -i delay="${1:-60}"
+
+	while (( delay > 0)) && pgrep -z "$ZONENAME" bhyve >/dev/null; do
+		force_halt=1
+		log "Force bhyve poweroff"
+		/usr/sbin/bhyvectl --vm="$ZONENAME" --force-poweroff
+		((delay % 5 == 0)) && log "Waiting for bhyve to exit"
+		((delay = delay - 5))
+		sleep 5
+	done
+
+	if ((force_halt)); then
+		log "bhyve poweroff done"
+	fi
 }
 
 cmd="${1:?cmd}"; shift
@@ -50,7 +69,8 @@ case $cmd in
 		;;
 	    $ZONE_STATE_RUNNING:$ZONE_STATE_CMD_HALT)
 		# halting (even as part of rebooting)
-		bhyve_shutdown 1800
+		bhyve_shutdown 60
+		bhyve_halt 60
 		;;
 	esac
 	;;

--- a/src/brand/bhyve/support
+++ b/src/brand/bhyve/support
@@ -21,13 +21,27 @@ bhyve_shutdown()
 {
 	typeset -i delay="${1:-60}"
 	log "Killing bhyve process - %d" $delay
-	pkill -z "$ZONENAME" bhyve
+	pkill -TERM -z "$ZONENAME" bhyve
 	while (( delay > 0 )) && pgrep -z "$ZONENAME" bhyve >/dev/null; do
-		((delay % 30 == 0)) && log "Waiting for bhyve to exit"
+		((delay % 5 == 0)) && log "Waiting for bhyve to exit"
 		((delay = delay - 1))
 		sleep 1
 	done
 	log "bhyve shutdown done"
+}
+
+bhyve_halt()
+{
+	typeset -i force_halt=0
+	while pgrep -z "$ZONENAME" bhyve >/dev/null; do
+		force_halt=1
+		log "Force bhyve poweroff"
+		/usr/sbin/bhyvectl --vm=$ZONENAME --force-poweroff
+		sleep 5
+	done
+	if ((force_halt)); then
+		log "bhyve poweroff done"
+	fi
 }
 
 cmd="${1:?cmd}"; shift
@@ -50,7 +64,8 @@ case $cmd in
 		;;
 	    $ZONE_STATE_RUNNING:$ZONE_STATE_CMD_HALT)
 		# halting (even as part of rebooting)
-		bhyve_shutdown 1800
+		bhyve_shutdown 20
+		bhyve_halt
 		;;
 	esac
 	;;


### PR DESCRIPTION
This code was written by Patrick van der Linden of EFit Partners.

Sometimes a VM can get in a state where it doesn't respond in reasonable time to shutdown request, such as when the OS isn't running yet or isn't running anymore, having crashed or otherwise locked up. In such a case, halting the zone can take a very long time.

This patch reduces the shutdown timeout from 30min to 20s in the default zone shutdown code, and introduces a force-poweroff in case the guest didn't shut down in time.

Here is a sample without the patch applied
```
:~$` time pfexec zoneadm -z bhwinlab25-02 shutdown
zone 'bhwinlab25-02': unable to shutdown zone

real    6m41.114s
user    0m0.002s
sys     0m0.003s

:~$ time pfexec zoneadm -z bhwinlab25-02 halt

real    30m9.890s
user    0m0.003s
sys     0m0.003s
```

Here is a sample with  the patch applied
The VM shudtowns as expected
```
:~$ time pfexec zoneadm -z bhwinlab25-02 shutdown

real    0m12.357s
user    0m0.003s
sys     0m0.003s
```

halting a zone when emulating a non responsive VM is very faster ;)
```
:~$ time pfexec zoneadm -z bhwinlab25-02 halt

real    0m27.074s
user    0m0.004s
sys     0m0.004s
```