### PR TITLE
brand/bhyve: Add support for virtio-scsi configuration.

### DIFF
--- a/src/brand/bhyve/boot.py
+++ b/src/brand/bhyve/boot.py
@@ -14,6 +14,7 @@
 # }}}
 
 # Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2026 EFit Partners
 
 import bundle
 import bootlib
@@ -124,6 +125,7 @@ PPT_SLOT        = 9
 RNG_SLOT        = 10
 VIRTFS_SLOT     = 11
 NET_SLOT2       = 12
+SCSI_SLOT       = 16
 CINIT_SLOT      = 29
 VNC_SLOT        = 30
 LPC_SLOT_WIN    = 31
@@ -474,9 +476,30 @@ try:
 except:
     pass
 
+# SCSI passthrough
+
+scsi_hba = {}
+for i, v in z.build_devlist('scsi', 8):
+    if (vv := z.findattr(f'scsi{i}')) is None:
+        vv = z.findattr('scsi')
+        index = 'scsi'
+    else:
+        index = f'scsi{i}'
+
+    if (vv) is not None:
+        backend_opts = [x.strip() for x in vv.get('value').split(',')]
+
+    scsi_hba[index] = {
+        'id': i,
+        'device': 'virtio-scsi',
+        'backend-opts': backend_opts,
+        'targets': [],
+    }
+
 # Additional Disks
 
-for i, v in z.build_devlist('disk', 16):
+nsd = 0
+for i, v in z.build_devlist('disk', 99):
     if (vv := z.findattr(f'diskif{i}')) is not None:
         diskif = vv.get('value')
         try:
@@ -486,18 +509,42 @@ for i, v in z.build_devlist('disk', 16):
     else:
         diskif = opts['diskif']
 
-    if i < 8:
+    if diskif.startswith('scsi') and diskif in scsi_hba:
+        scsi_hba[diskif]['targets'].append(diskpath(v))
+    elif nsd < 8:
         args.extend([
-            '-s', '{0}:{1},{2},{3}'.format(DISK_SLOT, i, diskif,
+            '-s', '{0}:{1},{2},{3}'.format(DISK_SLOT, nsd, diskif,
             diskpath(v))
         ])
-        add_bootoption('disk', i, ('pci', f'{DISK_SLOT}.{i}'))
+        add_bootoption('disk', nsd, ('pci', f'{DISK_SLOT}.{nsd}'))
+        nsd += 1
+    elif nsd < 16:
+        args.extend([
+            '-s', '{0}:{1},{2},{3}'.format(DISK_SLOT2, nsd - 8, diskif,
+            diskpath(v))
+        ])
+        add_bootoption(f'disk', nsd, ('pci', f'{DISK_SLOT2}.{nsd - 8}'))
+        nsd += 1
     else:
-        args.extend([
-            '-s', '{0}:{1},{2},{3}'.format(DISK_SLOT2, i - 8, diskif,
-            diskpath(v))
-        ])
-        add_bootoption(f'disk', i, ('pci', f'{DISK_SLOT2}.{i - 8}'))
+        fatal(f'unhandled disk configuration id: {nsd}')
+
+for v in scsi_hba.values():
+    scsi_hba_ctrl = '{0}:{1},{2}'.format(SCSI_SLOT, v['id'], v['device'])
+
+    if len(v['backend-opts']):
+        scsi_hba_opts = ',{0}'.format(','.join(list(v['backend-opts'])))
+    else:
+        scsi_hba_opts = ''
+
+    if len(v['targets']):
+        scsi_hba_targ = ',{0}'.format(
+            ','.join(list(map(lambda x: 'target=' + x , v['targets']))))
+    else:
+        scsi_hba_targ = ''
+
+    args.extend([
+        '-s', scsi_hba_ctrl + scsi_hba_opts + scsi_hba_targ
+    ])
 
 # Network
 

--- a/src/brand/bhyve/boot.py
+++ b/src/brand/bhyve/boot.py
@@ -14,6 +14,7 @@
 # }}}
 
 # Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2026 EFit Partners
 
 import bundle
 import bootlib
@@ -124,6 +125,7 @@ PPT_SLOT        = 9
 RNG_SLOT        = 10
 VIRTFS_SLOT     = 11
 NET_SLOT2       = 12
+SCSI_SLOT       = 16
 CINIT_SLOT      = 29
 VNC_SLOT        = 30
 LPC_SLOT_WIN    = 31
@@ -513,6 +515,47 @@ for i, v in z.build_devlist('disk', 16):
             diskpath(v))
         ])
         add_bootoption(f'disk', i, ('pci', f'{DISK_SLOT2}.{i - 8}'))
+
+# SCSI passthrough
+
+scsi_hba = {}
+backend_opts = []
+for i, v in z.build_devlist('scsi', 8):
+    if (vv := z.findattr(f'scsi{i}')) is None:
+        vv = z.findattr('scsi')
+        index = 'scsi'
+    else:
+        index = f'scsi{i}'
+
+    backend_opts = [x.strip() for x in vv.get('value').split(',')]
+
+    scsi_hba[index] = {
+        'id': i,
+        'device': 'virtio-scsi',
+        'backend-opts': backend_opts,
+        'targets': [],
+    }
+
+    for j, w in z.build_devlist(f'{index}-target', 256):
+        scsi_hba[index]['targets'].append(f'{j}:{diskpath(w)}')
+
+for v in scsi_hba.values():
+    scsi_hba_ctrl = '{0}:{1},{2}'.format(SCSI_SLOT, v['id'], v['device'])
+
+    if len(v['backend-opts']):
+        scsi_hba_opts = ',{0}'.format(','.join(v['backend-opts']))
+    else:
+        scsi_hba_opts = ''
+
+    if len(v['targets']):
+        scsi_hba_targ = ',{0}'.format(
+            ','.join(list(map(lambda x: 'target=' + x , v['targets']))))
+    else:
+        scsi_hba_targ = ''
+
+    args.extend([
+        '-s', scsi_hba_ctrl + scsi_hba_opts + scsi_hba_targ
+    ])
 
 # Network
 

--- a/src/brand/bhyve/boot.py
+++ b/src/brand/bhyve/boot.py
@@ -14,6 +14,7 @@
 # }}}
 
 # Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2026 EFit Partners
 
 import bundle
 import bootlib
@@ -124,6 +125,7 @@ PPT_SLOT        = 9
 RNG_SLOT        = 10
 VIRTFS_SLOT     = 11
 NET_SLOT2       = 12
+SCSI_SLOT       = 16
 CINIT_SLOT      = 29
 VNC_SLOT        = 30
 LPC_SLOT_WIN    = 31
@@ -498,6 +500,47 @@ for i, v in z.build_devlist('disk', 16):
             diskpath(v))
         ])
         add_bootoption(f'disk', i, ('pci', f'{DISK_SLOT2}.{i - 8}'))
+
+# SCSI passthrough
+
+scsi_hba = {}
+for i, v in z.build_devlist('scsi', 8):
+    if (vv := z.findattr(f'scsi{i}')) is None:
+        vv = z.findattr('scsi')
+        index = 'scsi'
+    else:
+        index = f'scsi{i}'
+
+    if (vv) is not None:
+        backend_opts = [x.strip() for x in vv.get('value').split(',')]
+
+    scsi_hba[index] = {
+        'id': i,
+        'device': 'virtio-scsi',
+        'backend-opts': backend_opts,
+        'targets': [],
+    }
+
+    for j, w in z.build_devlist('{0}-target'.format(index), 255):
+        scsi_hba[index]['targets'].append('{0}:{1}'.format(j, diskpath(w)))
+
+for v in scsi_hba.values():
+    scsi_hba_ctrl = '{0}:{1},{2}'.format(SCSI_SLOT, v['id'], v['device'])
+
+    if len(v['backend-opts']):
+        scsi_hba_opts = ',{0}'.format(','.join(list(v['backend-opts'])))
+    else:
+        scsi_hba_opts = ''
+
+    if len(v['targets']):
+        scsi_hba_targ = ',{0}'.format(
+            ','.join(list(map(lambda x: 'target=' + x , v['targets']))))
+    else:
+        scsi_hba_targ = ''
+
+    args.extend([
+        '-s', scsi_hba_ctrl + scsi_hba_opts + scsi_hba_targ
+    ])
 
 # Network
 

--- a/src/brand/bhyve/config.xml
+++ b/src/brand/bhyve/config.xml
@@ -81,10 +81,15 @@
 	<privilege set="default" name="file_owner" />
 	<privilege set="default" name="file_link_any" />
 
+	<!--
+		The following privilege is necessary for the uscsi backend of
+		virtio-scsi.
+	-->
+	<privilege set="default" name="sys_devices" />
+
 	<privilege set="prohibited" name="dtrace_kernel" />
 	<privilege set="prohibited" name="proc_zone" />
 	<privilege set="prohibited" name="sys_config" />
-	<privilege set="prohibited" name="sys_devices" />
 	<privilege set="prohibited" name="sys_ip_config" ip-type="shared" />
 	<privilege set="prohibited" name="sys_linkdir" />
 	<privilege set="prohibited" name="sys_net_config" />

--- a/src/brand/bhyve/config.xml
+++ b/src/brand/bhyve/config.xml
@@ -84,7 +84,6 @@
 	<privilege set="prohibited" name="dtrace_kernel" />
 	<privilege set="prohibited" name="proc_zone" />
 	<privilege set="prohibited" name="sys_config" />
-	<privilege set="prohibited" name="sys_devices" />
 	<privilege set="prohibited" name="sys_ip_config" ip-type="shared" />
 	<privilege set="prohibited" name="sys_linkdir" />
 	<privilege set="prohibited" name="sys_net_config" />

--- a/src/man/bhyve.7
+++ b/src/man/bhyve.7
@@ -11,8 +11,9 @@
 .\" Copyright 2016, Joyent, Inc.
 .\" Copyright 2016, OmniTI Computer Consulting, Inc. All Rights Reserved.
 .\" Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
+.\" Copyright 2026 EFit Partners
 .\"
-.Dd June 3, 2023
+.Dd March 25, 2026
 .Dt BHYVE 7
 .Os
 .Sh NAME
@@ -280,6 +281,8 @@ Available options are:
 .It
 .Sy nvme
 .It
+.Sy scsi Ns Oo Ar N Oc
+.It
 .Sy virtio-blk Pq default
 .El
 .\" diskifN
@@ -474,6 +477,49 @@ for the default user and/or the root user.
 .Ar sshkey
 can be provided as a fixed string or a path to a file that contains the desired
 public key.
+.\" scsi
+.It Ic scsi Ns Oo Ar N Oc Ar scsi-config
+.Pp
+Specifies a
+.Sy virtio-scsi
+controller configuration.
+To configure multiple
+.Sy virtio-scsi controllers, create multiple attributes with
+different values of
+.Ar N .
+In that case, each
+.Sy virtio-scsi
+controller will be configured as a separate PCI function
+.Ar N .
+If only a single
+.Sy virtio-scsi
+controller is required,
+.Ar N
+can be omitted.
+The
+.Ar scsi-config
+argument is a comma-separated list of assignments of any of the following
+.Sy virtio-scsi
+properties:
+.Bl -tag -width Ds
+.It Ic backend
+Specifies the backend to use.
+Currently the only valid backend is the
+.Qq Sy uscsi
+backend.
+.It Ic ctl_ringsz
+The ring size of the control queue.
+.It Ic evt_ringsz
+The ring size of the event queue.
+.It Ic req_ringsz
+The ring size of each I/O request queue.
+.It Ic num_queues
+The number of I/O request queues.
+.It Ic thr_per_q
+The number of parallel request processing threads per I/O request queue.
+.It seg_max
+The maximum number of segments allowed in a single I/O request.
+.El
 .\" type
 .It Ic type Ar type
 .Pp
@@ -720,7 +766,7 @@ add attr
 end
 .Ed
 .Pp
-and to share the global zone filesystem
+To share the global zone filesystem
 .Pa /data/websites
 read-only to the guest, add:
 .Bd -literal -offset indent
@@ -737,9 +783,110 @@ add attr
     set value=websites,/data/websites,ro
 end
 .Ed
+.Pp
+The following examples shows how to configure SCSI device passthrough using
+.Sy virtio-scsi
+with the
+.Sy uscsi
+backend.
+.Pp
+To configure a single
+.Sy virtio-scsi
+controller with a single target
+.Pa c0t5000039668186AD9d0 ,
+add:
+.Bd -literal -offset indent
+add device
+    set match="/dev/rdsk/c0t5000039668186AD9d0"
+end
+add attr
+    set name="scsi"
+    set type="string"
+    set value="backend=uscsi"
+end
+add attr
+    set name="disk0"
+    set type="string"
+    set value="/dev/rdsk/c0t5000039668186AD9d0"
+end
+add attr
+    set name="diskif0"
+    set type="string"
+    set value="scsi"
+end
+.Ed
+.Pp
+A more complex configuration using two
+.Sy virtio-scsi
+controllers, additional I/O queues, and two targets each could look like this:
+.Bd -literal -offset indent
+add device
+    set match="/dev/rdsk/c0t5000039668186AD9d0"
+end
+add device
+    set match="/dev/rdsk/c0t50000396681866A5d0"
+end
+add device
+    set match="/dev/rdsk/c0t50000396681B21F5d0"
+end
+add device
+    set match="/dev/rdsk/c0t50000396681AFF1Dd0"
+end
+add attr
+    set name="scsi0"
+    set type="string"
+    set value="backend=uscsi,num_queues=4"
+end
+add attr
+    set name="scsi1"
+    set type="string"
+    set value="backend=uscsi,num_queues=4"
+end
+add attr
+    set name="disk0"
+    set type="string"
+    set value="/dev/rdsk/c0t5000039668186AD9d0"
+end
+add attr
+    set name="disk1"
+    set type="string"
+    set value="/dev/rdsk/c0t50000396681866A5d0"
+end
+add attr
+    set name="disk2"
+    set type="string"
+    set value="/dev/rdsk/c0t50000396681B21F5d0"
+end
+add attr
+    set name="disk3"
+    set type="string"
+    set value="/dev/rdsk/c0t50000396681AFF1Dd0"
+end
+add attr
+    set name="diskif0"
+    set type="string"
+    set value="scsi0"
+end
+add attr
+    set name="diskif1"
+    set type="string"
+   set value="scsi0"
+end
+add attr
+    set name="diskif2"
+    set type="string"
+    set value="scsi1"
+end
+add attr
+    set name="diskif3"
+    set type="string"
+    set value="scsi1"
+end
+.Ed
 .Sh SEE ALSO
 .Xr mdb 1 ,
 .Xr proc 1 ,
+.Xr bhyve_config 5 ,
 .Xr brands 7 ,
 .Xr privileges 7 ,
 .Xr resource_controls 7 ,

--- a/src/man/bhyve.7
+++ b/src/man/bhyve.7
@@ -11,8 +11,9 @@
 .\" Copyright 2016, Joyent, Inc.
 .\" Copyright 2016, OmniTI Computer Consulting, Inc. All Rights Reserved.
 .\" Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
+.\" Copyright 2026 EFit Partners
 .\"
-.Dd June 3, 2023
+.Dd March 25, 2026
 .Dt BHYVE 7
 .Os
 .Sh NAME
@@ -514,6 +515,110 @@ for the default user and/or the root user.
 .Ar sshkey
 can be provided as a fixed string or a path to a file that contains the desired
 public key.
+.\" scsi
+.It Ic scsi Ns Oo Ar N Oc Ar scsi-config
+.Pp
+Specifies a
+.Sy virtio-scsi
+controller configuration.
+To configure multiple
+.Sy virtio-scsi
+controllers, create multiple attributes with different values of
+.Ar N .
+In that case, each
+.Sy virtio-scsi
+controller will be configured as a separate PCI function
+.Ar N .
+If only a single
+.Sy virtio-scsi
+controller is required,
+.Ar N
+can be omitted.
+The
+.Ar scsi-config
+argument is a comma-separated list of assignments of any of the following
+.Sy virtio-scsi
+properties:
+.Bl -tag -width Ds
+.It Ic backend
+Specifies the backend to use.
+Currently the only valid backend is the
+.Qq Sy uscsi
+backend.
+.It Ic ctl_ringsz
+The ring size of the control queue.
+.It Ic evt_ringsz
+The ring size of the event queue.
+.It Ic req_ringsz
+The ring size of each I/O request queue.
+.It Ic num_queues
+The number of I/O request queues.
+.It Ic thr_per_q
+The number of parallel request processing threads per I/O request queue.
+.It Ic seg_max
+The maximum number of segments allowed in a single I/O request.
+.El
+.Pp
+Note that
+.Sy virtio-scsi
+requires the
+.Sy sys_devices
+privilege, which needs to be explicitly enabled using the
+.Sy limitpriv
+property.
+.\" scsi-target
+.It Ic scsi Ns Oo Ar N Oc Ns \&-target Ns Oo Ar M Oc
+.Pp
+Configures the device node at
+.Ar path
+as
+.Sy virtio-scsi
+target with SCSI ID
+.Ar M
+connected to the
+.Sy virtio-scsi
+controller
+.Sy scsi Ns Oo Ar N Oc .
+If only one unnumbered
+.Sy virtio-scsi
+controller is configured,
+.Ar N
+can be omitted.
+The target SCSI ID
+.Ar M
+can be freely assigned in the range
+.Ar [ 0, 255 ]
+and must be unique for each target within a single controller.
+.Pp
+Care must be taken that the device node at
+.Ar path
+is usable by the backend configured for the
+.Sy virtio-scsi
+controller it is attached to.
+E.g. a
+.Sy virtio-scsi
+controller
+using the
+.Sy uscsi
+backend requires target devices that support the
+.Xr uscsi 4i
+interface, such as devices connected through
+.Sy FibreChannel ,
+.Sy SCSI ,
+.Sy SAS ,
+.Sy SATA ,
+.Sy USB mass storage ,
+or
+.Sy iSCSI ,
+just to name a few.
+.Pp
+Note that
+.Sy virtio-scsi
+requires the
+.Sy sys_devices
+privilege, which needs to be explicitly enabled using the
+.Sy limitpriv
+property.
 .\" type
 .It Ic type Ar type
 .Pp
@@ -760,7 +865,7 @@ add attr
 end
 .Ed
 .Pp
-and to share the global zone filesystem
+To share the global zone filesystem
 .Pa /data/websites
 read-only to the guest, add:
 .Bd -literal -offset indent
@@ -777,9 +882,87 @@ add attr
     set value=websites,/data/websites,ro
 end
 .Ed
+.Pp
+The following examples shows how to configure SCSI device passthrough using
+.Sy virtio-scsi
+with the
+.Sy uscsi
+backend.
+.Pp
+To configure a single
+.Sy virtio-scsi
+controller with a single target
+.Pa c0t5000039668186AD9d0 ,
+add:
+.Bd -literal -offset indent
+set limitpriv=default,sys_devices
+add device
+    set match="/dev/rdsk/c0t5000039668186AD9d0"
+end
+add attr
+    set name="scsi"
+    set type="string"
+    set value="backend=uscsi"
+end
+add attr
+    set name="scsi-target0"
+    set type="string"
+    set value="/dev/rdsk/c0t5000039668186AD9d0"
+end
+.Ed
+.Pp
+A more complex configuration using two
+.Sy virtio-scsi
+controllers, additional I/O queues, and two targets each could look like this:
+.Bd -literal -offset indent
+set limitpriv=default,sys_devices
+add device
+    set match="/dev/rdsk/c0t5000039668186AD9d0"
+end
+add device
+    set match="/dev/rdsk/c0t50000396681866A5d0"
+end
+add device
+    set match="/dev/rdsk/c0t50000396681B21F5d0"
+end
+add device
+    set match="/dev/rdsk/c0t50000396681AFF1Dd0"
+end
+add attr
+    set name="scsi0"
+    set type="string"
+    set value="backend=uscsi,num_queues=4"
+end
+add attr
+    set name="scsi1"
+    set type="string"
+    set value="backend=uscsi,num_queues=4"
+end
+add attr
+    set name="scsi0-target0"
+    set type="string"
+    set value="/dev/rdsk/c0t5000039668186AD9d0"
+end
+add attr
+    set name="scsi0-target1"
+    set type="string"
+    set value="/dev/rdsk/c0t50000396681866A5d0"
+end
+add attr
+    set name="scsi1-target0"
+    set type="string"
+    set value="/dev/rdsk/c0t50000396681B21F5d0"
+end
+add attr
+    set name="scsi1-target1"
+    set type="string"
+    set value="/dev/rdsk/c0t50000396681AFF1Dd0"
+end
+.Ed
 .Sh SEE ALSO
 .Xr mdb 1 ,
 .Xr proc 1 ,
+.Xr bhyve_config 5 ,
 .Xr brands 7 ,
 .Xr privileges 7 ,
 .Xr resource_controls 7 ,

--- a/src/man/bhyve.7
+++ b/src/man/bhyve.7
@@ -11,8 +11,9 @@
 .\" Copyright 2016, Joyent, Inc.
 .\" Copyright 2016, OmniTI Computer Consulting, Inc. All Rights Reserved.
 .\" Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
+.\" Copyright 2026 EFit Partners
 .\"
-.Dd June 3, 2023
+.Dd March 25, 2026
 .Dt BHYVE 7
 .Os
 .Sh NAME
@@ -474,6 +475,94 @@ for the default user and/or the root user.
 .Ar sshkey
 can be provided as a fixed string or a path to a file that contains the desired
 public key.
+.\" scsi
+.It Ic scsi Ns Oo Ar N Oc Ar scsi-config
+.Pp
+Specifies a
+.Sy virtio-scsi
+controller configuration.
+To configure multiple
+.Sy virtio-scsi
+controllers, create multiple attributes with different values of
+.Ar N .
+In that case, each
+.Sy virtio-scsi
+controller will be configured as a separate PCI function
+.Ar N .
+If only a single
+.Sy virtio-scsi
+controller is required,
+.Ar N
+can be omitted.
+The
+.Ar scsi-config
+argument is a comma-separated list of assignments of any of the following
+.Sy virtio-scsi
+properties:
+.Bl -tag -width Ds
+.It Ic backend
+Specifies the backend to use.
+Currently the only valid backend is the
+.Qq Sy uscsi
+backend.
+.It Ic ctl_ringsz
+The ring size of the control queue.
+.It Ic evt_ringsz
+The ring size of the event queue.
+.It Ic req_ringsz
+The ring size of each I/O request queue.
+.It Ic num_queues
+The number of I/O request queues.
+.It Ic thr_per_q
+The number of parallel request processing threads per I/O request queue.
+.It seg_max
+The maximum number of segments allowed in a single I/O request.
+.El
+.\" scsi-target
+.It Ic scsi Ns Oo Ar N Oc Ns \&-target Ns Oo Ar M Oc
+.Pp
+Configures the device node at
+.Ar path
+as
+.Sy virtio-scsi
+target with SCSI ID
+.Ar M
+connected to the
+.Sy virtio-scsi
+controller
+.Sy scsi Ns Oo Ar N Oc .
+If only one unnumbered
+.Sy virtio-scsi
+controller is configured,
+.Ar N
+can be omitted.
+The target SCSI ID
+.Ar M
+can be freely assigned in the range
+.Ar [ 0, 255 ]
+and must be unique for each target within a single controller.
+.Pp
+Care must be taken that the device node at
+.Ar path
+is usable by the backend configured for the
+.Sy virtio-scsi
+controller it is attached to.
+E.g. a
+.Sy virtio-scsi
+controller
+using the
+.Sy uscsi
+backend requires target devices that support the
+.Xr uscsi 4i
+interface, such as devices connected through
+.Sy FibreChannel ,
+.Sy SCSI ,
+.Sy SAS ,
+.Sy SATA ,
+.Sy USB mass storage ,
+or
+.Sy iSCSI ,
+just to name a few.
 .\" type
 .It Ic type Ar type
 .Pp
@@ -720,7 +809,7 @@ add attr
 end
 .Ed
 .Pp
-and to share the global zone filesystem
+To share the global zone filesystem
 .Pa /data/websites
 read-only to the guest, add:
 .Bd -literal -offset indent
@@ -737,9 +826,85 @@ add attr
     set value=websites,/data/websites,ro
 end
 .Ed
+.Pp
+The following examples shows how to configure SCSI device passthrough using
+.Sy virtio-scsi
+with the
+.Sy uscsi
+backend.
+.Pp
+To configure a single
+.Sy virtio-scsi
+controller with a single target
+.Pa c0t5000039668186AD9d0 ,
+add:
+.Bd -literal -offset indent
+add device
+    set match="/dev/rdsk/c0t5000039668186AD9d0"
+end
+add attr
+    set name="scsi"
+    set type="string"
+    set value="backend=uscsi"
+end
+add attr
+    set name="scsi-target0"
+    set type="string"
+    set value="/dev/rdsk/c0t5000039668186AD9d0"
+end
+.Ed
+.Pp
+A more complex configuration using two
+.Sy virtio-scsi
+controllers, additional I/O queues, and two targets each could look like this:
+.Bd -literal -offset indent
+add device
+    set match="/dev/rdsk/c0t5000039668186AD9d0"
+end
+add device
+    set match="/dev/rdsk/c0t50000396681866A5d0"
+end
+add device
+    set match="/dev/rdsk/c0t50000396681B21F5d0"
+end
+add device
+    set match="/dev/rdsk/c0t50000396681AFF1Dd0"
+end
+add attr
+    set name="scsi0"
+    set type="string"
+    set value="backend=uscsi,num_queues=4"
+end
+add attr
+    set name="scsi1"
+    set type="string"
+    set value="backend=uscsi,num_queues=4"
+end
+add attr
+    set name="scsi0-target0"
+    set type="string"
+    set value="/dev/rdsk/c0t5000039668186AD9d0"
+end
+add attr
+    set name="scsi0-target1"
+    set type="string"
+    set value="/dev/rdsk/c0t50000396681866A5d0"
+end
+add attr
+    set name="scsi1-target0"
+    set type="string"
+    set value="/dev/rdsk/c0t50000396681B21F5d0"
+end
+add attr
+    set name="scsi1-target1"
+    set type="string"
+    set value="/dev/rdsk/c0t50000396681AFF1Dd0"
+end
+.Ed
 .Sh SEE ALSO
 .Xr mdb 1 ,
 .Xr proc 1 ,
+.Xr bhyve_config 5 ,
 .Xr brands 7 ,
 .Xr privileges 7 ,
 .Xr resource_controls 7 ,


### PR DESCRIPTION
This code was written by Patrick van der Linden of EFit Partners. I made a significant overhaul and wrote the new manpage content.

Virtio-SCSI is a bit different from other device emulations, as there needs to be a configuration for the virtio-scsi HBA and then one for each of the targets assigned to it. It's possible to have multiple HBAs with multiple targets on each:

```
add attr
    set name="scsi0"
    set type="string"
    set value="backend=uscsi"
end
add attr
    set name="scsi0-target4"
    set type="string"
    set value="/dev/rdsk/c0t600144F0766CCA0600006A5BDD420005d0p0"
end
add attr
    set name="scsi0-target5"
    set type="string"
    set value="/dev/rdsk/c0t600144F0766CCA0600006A5BDD430006d0p0"
end
```