### PR TITLE
brand/bhyve: add virtio-consoleN attribute

### DIFF
--- a/src/brand/bhyve/boot.py
+++ b/src/brand/bhyve/boot.py
@@ -124,6 +124,7 @@ PPT_SLOT        = 9
 RNG_SLOT        = 10
 VIRTFS_SLOT     = 11
 NET_SLOT2       = 12
+CONSOLE_SLOT    = 17
 CINIT_SLOT      = 29
 VNC_SLOT        = 30
 LPC_SLOT_WIN    = 31
@@ -459,6 +460,13 @@ for i, v in z.build_devlist('com', 4):
 # Console
 
 args.extend(['-l', 'com1,{0}'.format(opts['console'])])
+
+# virtio-console/serial devices
+
+for i, v in z.build_devlist('virtio-console', 4):
+    args.extend([
+        '-s', '{0}:{1},virtio-console,{2}'.format(CONSOLE_SLOT, i, v)
+    ])
 
 # CDROM
 

--- a/src/man/bhyve.7
+++ b/src/man/bhyve.7
@@ -11,8 +11,9 @@
 .\" Copyright 2016, Joyent, Inc.
 .\" Copyright 2016, OmniTI Computer Consulting, Inc. All Rights Reserved.
 .\" Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
+.\" Copyright 2026 EFit Partners
 .\"
-.Dd June 3, 2023
+.Dd August 27, 2026
 .Dt BHYVE 7
 .Os
 .Sh NAME
@@ -588,6 +589,19 @@ mount.
 See the
 .Sx EXAMPLES
 section below.
+.\" virtio-console
+.It Ic virtio-console Ns Oo Ar N Oc Ar name Ns = Ns path
+.Pp
+Configures a named virtio-console device.
+The
+.Ar name
+is the name of the device as seen by the guest,
+.Ar path
+is the path to a socket in the zone to be used for I/O.
+.Pp
+See the
+.Sx EXAMPLES
+section below.
 .\" vga
 .It Ic vga Ar off Ns | Ns Ar on Ns | Ns Ar io
 .Pp
@@ -729,6 +743,11 @@ add attr
     set name=cdrom
     set type=string
     set value=/rpool/iso/debian-9.4.0-amd64-netinst.iso
+end
+add attr
+    set name=virtio-console
+    set type=string
+    set value="org.qemu.guest_agent.0=/tmp/vm.qga.sock"
 end
 .Ed
 .Pp


### PR DESCRIPTION
This attribute allow configuration of virtio-console ports, which are really just serial ports based on virtio. There is currently no support for console virtio-console.

This code was written by Patrick van der Linden of EFit Partners.