### PR TITLE
brand/bhyve: support setting bhyve binary path

### DIFF
--- a/src/brand/bhyve/boot.py
+++ b/src/brand/bhyve/boot.py
@@ -56,6 +56,7 @@ FBUF_SIZE       = 16 * MiB
 # Default values
 opts = {
     'acpi':             'on',       # No effect on illumos bhyve
+    'bhyve':		'/usr/sbin/bhyve',
     'bootorder':        'path0,bootdisk,cdrom0',
     "bootnext":         None,
     'bootrom':          'BHYVE_RELEASE_CSM',
@@ -398,7 +399,8 @@ debug(f'Final uuid: {uuid}')
 
 ##############################################################################
 
-args = ['/usr/sbin/bhyve']
+args = []
+args.append(opts['bhyve'])
 
 ser = uuid
 
@@ -788,6 +790,14 @@ if not testmode:
         fatal(f'Could not create bhyve.cfg from temporary file: {e}')
     else:
         info(f'Successfully created {z.zoneroot}/etc/bhyve.cfg')
+
+if not testmode:
+    try:
+        shutil.copy(opts['bhyve'], f'{z.zoneroot}/tmp/bhyve')
+    except Exception as e:
+        fatal(f'Could not copy bhyve binary: {e}')
+    else:
+        debug(f'Copied bhyve binary from {opts['bhyve']}')
 
 # Vim hints
 # vim:ts=4:sw=4:et:fdm=marker

--- a/src/brand/bhyve/init.c
+++ b/src/brand/bhyve/init.c
@@ -142,7 +142,6 @@ int
 main(int argc __unused, char **argv __unused)
 {
 	char zonename[ZONENAME_MAX];
-
 	char *args[] = {
 		NULL,
 		"-k", "/etc/bhyve.cfg",
@@ -159,7 +158,7 @@ main(int argc __unused, char **argv __unused)
 	if (asprintf(&args[0], "bhyve-%s", zonename) == -1)
 		args[0] = "bhyve";
 
-	(void) execv("/usr/sbin/bhyve", args);
+	(void) execv("/tmp/bhyve", args);
 	err(EXIT_FAILURE, "execv failed");
 
 	/* NOTREACHED */


### PR DESCRIPTION
This change allows selecting a different bhyve binary to run:

```
add attr
     set name=bhyve
     set type=string
     set value=/usr/sbin/bhyve-experimental
end
```

The selected bhyve binary must exist in both the global zone and the bhyve zone at the same path. Due to lofs mounts of /usr into the zone this happens to be the case if the bhyve binary resides somewhere in /usr in the global zone.

Perhaps it would be a good idea to just copy the selected bhyve binary into <zoneroot>/tmp and run it from there, allowing it to reside anywhere in the global zone and obviating the need for bhyve.env?